### PR TITLE
Add the ability to update crash report states.

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -20,10 +20,5 @@ handlers:
   http_headers:
     Cache-Control: max-age=31556926
 
-- url: /admin
-  script: main.application
-  login: admin
-  secure: always
-
 - url: .*
   script: main.application

--- a/app.yaml
+++ b/app.yaml
@@ -4,6 +4,9 @@ runtime: python27
 api_version: 1
 threadsafe: true
 
+builtins:
+- deferred: on
+
 libraries:
 - name: jinja2
   version: latest
@@ -16,6 +19,11 @@ handlers:
   static_dir: static
   http_headers:
     Cache-Control: max-age=31556926
+
+- url: /admin
+  script: main.application
+  login: admin
+  secure: always
 
 - url: .*
   script: main.application

--- a/main.py
+++ b/main.py
@@ -34,7 +34,7 @@ class RootHandler(webapp2.RequestHandler):
         directory_links.append(Link('Trending Crashes', uri_for('trending_crashes')))
         directory_links.append(Link('Submit Crash', uri_for('submit_crash')))
         directory_links.append(Link('View Crash', uri_for('view_crash')))
-        directory_links.append(Link('Update Crash Report State', uri_for('update_crash_state')))
+        directory_links.append(Link('Update Crash Report', uri_for('update_crash_state')))
         self.add_parameter('directory_links', directory_links)
         self.render('index.html')
 

--- a/main.py
+++ b/main.py
@@ -126,7 +126,8 @@ application = webapp2.WSGIApplication(
         webapp2.Route('/crashes/submit', handler='main.SubmitCrashHandler', name='submit_crash'),
         webapp2.Route('/crashes', handler='main.ViewCrashHandler', name='view_crash'),
         webapp2.Route('/trending', handler='main.TrendingCrashesHandler', name='trending_crashes'),
-        webapp2.Route('/admin/crashes/upgrade', handler='update_schema.UpdateSchemaHandler', name='update_crash_reports'),
+        webapp2.Route('/admin/crashes/upgrade',
+                      handler='update_schema.UpdateSchemaHandler', name='update_crash_reports'),
     ]
     , debug=True
 )

--- a/main.py
+++ b/main.py
@@ -1,12 +1,12 @@
+import StringIO
+import csv
+
 import webapp2
 from webapp2 import uri_for
 
 from common import common_request
 from model import CrashReport, Link
 from util import CrashReports
-
-import csv
-import StringIO
 
 
 class RequestHandlerUtils(object):
@@ -126,6 +126,7 @@ application = webapp2.WSGIApplication(
         webapp2.Route('/crashes/submit', handler='main.SubmitCrashHandler', name='submit_crash'),
         webapp2.Route('/crashes', handler='main.ViewCrashHandler', name='view_crash'),
         webapp2.Route('/trending', handler='main.TrendingCrashesHandler', name='trending_crashes'),
+        webapp2.Route('/admin/crashes/upgrade', handler='update_schema.UpdateSchemaHandler', name='update_crash_reports'),
     ]
     , debug=True
 )

--- a/main.py
+++ b/main.py
@@ -34,6 +34,7 @@ class RootHandler(webapp2.RequestHandler):
         directory_links.append(Link('Trending Crashes', uri_for('trending_crashes')))
         directory_links.append(Link('Submit Crash', uri_for('submit_crash')))
         directory_links.append(Link('View Crash', uri_for('view_crash')))
+        directory_links.append(Link('Update Crash Report State', uri_for('update_crash_state')))
         self.add_parameter('directory_links', directory_links)
         self.render('index.html')
 
@@ -101,6 +102,34 @@ class ViewCrashHandler(webapp2.RequestHandler):
         self.render('show-crash.html')
 
 
+class UpdateCrashStateHandler(webapp2.RequestHandler):
+    def common(self, handler):
+        handler.add_parameter('title', 'Update Crash State')
+        handler.add_breadcrumb('Home', uri_for('home'))
+        handler.add_breadcrumb('Update Crash State', uri_for('update_crash_state'))
+        RequestHandlerUtils.add_brand(handler)
+        RequestHandlerUtils.add_nav_links(handler)
+
+    @common_request
+    def get(self):
+        self.request_handler.common(self)
+        self.render('update-crash-state.html')
+
+    @common_request
+    def post(self):
+        self.request_handler.common(self)
+        if not self.empty_query_string('fingerprint', 'state'):
+            fingerprint = self.get_parameter('fingerprint')
+            state = self.get_parameter('state', default_value='unresolved',
+                                       valid_iter=['unresolved', 'pending', 'submitted', 'resolved'])
+            crash_report = CrashReports.update_report_state(fingerprint, state)
+            if crash_report:
+                crash_report_item = CrashReport.to_json(crash_report)
+                self.add_parameter('crash_report', crash_report_item)
+                self.add_to_json('crash_report', crash_report_item)
+        self.render('update-crash-state.html')
+
+
 class TrendingCrashesHandler(webapp2.RequestHandler):
     def common(self, handler):
         handler.add_parameter('title', 'Show Crash')
@@ -123,6 +152,7 @@ class TrendingCrashesHandler(webapp2.RequestHandler):
 application = webapp2.WSGIApplication(
     [
         webapp2.Route('/', handler='main.RootHandler', name='home'),
+        webapp2.Route('/crashes/state/update', handler='main.UpdateCrashStateHandler', name='update_crash_state'),
         webapp2.Route('/crashes/submit', handler='main.SubmitCrashHandler', name='submit_crash'),
         webapp2.Route('/crashes', handler='main.ViewCrashHandler', name='view_crash'),
         webapp2.Route('/trending', handler='main.TrendingCrashesHandler', name='trending_crashes'),

--- a/main.py
+++ b/main.py
@@ -156,8 +156,6 @@ application = webapp2.WSGIApplication(
         webapp2.Route('/crashes/submit', handler='main.SubmitCrashHandler', name='submit_crash'),
         webapp2.Route('/crashes', handler='main.ViewCrashHandler', name='view_crash'),
         webapp2.Route('/trending', handler='main.TrendingCrashesHandler', name='trending_crashes'),
-        webapp2.Route('/admin/crashes/upgrade',
-                      handler='update_schema.UpdateSchemaHandler', name='update_crash_reports'),
     ]
     , debug=True
 )

--- a/model.py
+++ b/model.py
@@ -47,6 +47,8 @@ class CrashReport(db.Expando):
     fingerprint = db.StringProperty(required=True)
     date_time = db.DateTimeProperty(required=True, auto_now_add=True)
     count = db.IntegerProperty(default=0)
+    # state can be one of 'unresolved'|'pending'|'submitted'|'resolved'
+    state = db.StringProperty(default='unresolved')
 
     @classmethod
     def get_count(cls, name):
@@ -58,25 +60,46 @@ class CrashReport(db.Expando):
             q.filter('name = ', name)
             for entity in q.run():
                 total += entity.count
-            ''' total can be a string (when cached) for 2 mins '''
-            memcache.set(cache_key, str(total), 120)
+            memcache.set(cache_key, str(total))
         return int(total)
 
     @classmethod
-    def most_recent_crash(cls, name):
-        cache_key = CrashReport.recent_crash_cache_key(name)
-        most_recent = memcache.get(cache_key)
-        if most_recent is None:
+    def _most_recent_property(
+            cls, name, property_name, default_value=None, serialize=lambda x: x, deserialize=lambda x: x, ttl=120):
+
+        cache_key = CrashReport.recent_crash_property_key(name, property_name)
+        most_recent_value = memcache.get(cache_key)
+        if most_recent_value is None:
             most_recent = 0
+            most_recent_value = default_value
+
             q = CrashReport.all()
             q.filter('name = ', name)
             for entity in q.run():
                 in_millis = to_milliseconds(entity.date_time)
                 if most_recent <= in_millis:
                     most_recent = in_millis
-            '''most_recent can be a string (when cached) for 2 mins'''
-            memcache.set(cache_key, str(most_recent), 120)
-        return int(most_recent)
+                    most_recent_value = serialize(entity.__getattribute__(property_name))
+            memcache.set(cache_key, most_recent_value, ttl)
+        to_return = deserialize(most_recent_value)
+        return to_return
+
+    @classmethod
+    def most_recent_crash(cls, name):
+        return CrashReport._most_recent_property(
+            name, 'date_time', serialize=lambda x: str(to_milliseconds(x)), deserialize=lambda x: int(x))
+
+    @classmethod
+    def most_recent_labels(cls, name):
+        return CrashReport._most_recent_property(
+            name, 'labels',
+            default_value=list(),
+            serialize=lambda x: ','.join(x),
+            deserialize=lambda x: x.split(','))
+
+    @classmethod
+    def most_recent_state(cls, name):
+        return CrashReport._most_recent_property(name, 'state', default_value='unresolved')
 
     @classmethod
     def add_or_remove(cls, fingerprint, crash, labels=None, is_add=True, delta=1):
@@ -92,7 +115,6 @@ class CrashReport(db.Expando):
             crash_report.put()
             # update caches
             memcache.incr(CrashReport.count_cache_key(key_name), delta, initial_value=0)
-            memcache.set(CrashReport.recent_crash_cache_key(key_name), to_milliseconds(crash_report.date_time))
         else:
             crash_report.count -= delta
             crash_report.put()
@@ -118,18 +140,19 @@ class CrashReport(db.Expando):
         return 'total_%s' % name
 
     @classmethod
-    def recent_crash_cache_key(cls, name):
-        return 'most_recent_%s' % name
+    def recent_crash_property_key(cls, name, property_name):
+        return 'most_recent_%s/%s' % (name, property_name)
 
     @classmethod
     def to_json(cls, entity):
         return {
             'key': unicode(entity.key()),
             'crash': entity.crash,
-            'labels': entity.labels or list(),
+            'labels': CrashReport.most_recent_labels(entity.name),
             'fingerprint': entity.fingerprint,
             'time': CrashReport.most_recent_crash(entity.name),  # in millis
-            'count': CrashReport.get_count(entity.name)
+            'count': CrashReport.get_count(entity.name),
+            'state': CrashReport.most_recent_state(entity.name)
         }
 
 

--- a/pages/crash-report-macro.html
+++ b/pages/crash-report-macro.html
@@ -6,6 +6,12 @@
             <span class="badge">Count {{ crash_report.count }}</span>
             <b>Fingerprint : </b> <code>{{ crash_report.fingerprint }}</code>
         </li>
+        {% if crash_report.state %}
+          <li class="list-group-item">
+            <span class="badge">{{ crash_report.state }}</span>
+            <b>State </b>
+          </li>
+        {% endif %}
         {% if crash_report.labels %}
           <li class="list-group-item">
             {% for label in crash_report.labels %}

--- a/pages/update-crash-state.html
+++ b/pages/update-crash-state.html
@@ -1,0 +1,58 @@
+{% extends "base.html" %}
+{% from 'breadcrumbs-macro.html' import render_breadcrumbs %}
+{% from 'nav-macro.html' import render_navbar %}
+{% from 'messages-macro.html' import render_messages %}
+{% from 'crash-report-macro.html' import render_crash_report %}
+
+{% block navbar %}
+  {{ render_navbar (brand=rrequest.params.brand, links=rrequest.params.nav_links) }}
+{% endblock %}
+
+{% block main %}
+  {# render breadcrumbs #}
+  {{ render_breadcrumbs(crumbs=rrequest.breadcrumbs) }}
+
+   <h2>Update Crash Report State<small></small></h2>
+
+  <div class="row">
+    <div class="col-md-8">
+      <form method="post" class="well">
+        <div class="form-group">
+          <label for="fingerprint">Enter Fingerprint</label>
+          <input name="fingerprint" id="fingerprint" type="text" />
+        </div>
+        <div class="form-group">
+          <label for="state">State</label>
+          <select name="state" id="state">
+            <option value="unresolved">Unresolved</option>
+            <option value="pending">Pending</option>
+            <option value="submitted">Submitted</option>
+            <option value="resolved">Resolved</option>
+          </select>
+        </div>
+        <div class="form-group">
+          <label for="f">Response Format</label>
+          <select name="f" id="f">
+            <option value="html">HTML</option>
+            <option value="json">JSON</option>
+          </select>
+        </div>
+        <div class="form-group">
+          <label for="pretty">Prettyify</label>
+          <select name="pretty" id="pretty">
+            <option value="true">True</option>
+            <option value="false">False</option>
+          </select>
+        </div>
+        <button type="submit" class="btn btn-default">Submit</button>
+      </form>
+    </div>
+  </div>
+
+  {# render crash report #}
+  {{ render_crash_report(crash_report = rrequest.params.crash_report) }}
+
+  {# render messages #}
+  {{ render_messages(messages=rrequest.messages) }}
+
+{% endblock %}

--- a/search_model.py
+++ b/search_model.py
@@ -19,24 +19,43 @@ class Search(object):
             index.delete(document_ids)
 
     @classmethod
+    def crash_report_to_document(cls, crash_report):
+        if not crash_report:
+            return None
+
+        fields = [
+            search.AtomField(name='key', value=unicode(crash_report.key())),
+            search.AtomField(name='fingerprint', value=crash_report.fingerprint),
+            search.TextField(name='crash', value=crash_report.crash),
+            search.DateField(name='time', value=crash_report.date_time),
+            search.NumberField(name='count', value=CrashReport.get_count(crash_report.name)),
+            search.AtomField(name='state', value=crash_report.state),
+        ]
+        labels = [search.TextField(name='labels', value=label)
+                  for label in crash_report.labels]
+        fields.extend(labels)
+        document = search.Document(doc_id=crash_report.name, fields=fields)
+        return document
+
+    @classmethod
     def add_to_index(cls, crash_report):
         if crash_report:
-            fields = [
-                search.AtomField(name='key', value=unicode(crash_report.key())),
-                search.AtomField(name='fingerprint', value=crash_report.fingerprint),
-                search.TextField(name='crash', value=crash_report.crash),
-                search.DateField(name='time', value=crash_report.date_time),
-                search.NumberField(name='count', value=CrashReport.get_count(crash_report.name))
-            ]
-            labels = [search.TextField(name='labels', value=label)
-                      for label in crash_report.labels]
-            fields.extend(labels)
-            document = search.Document(doc_id=crash_report.name, fields=fields)
+            document = Search.crash_report_to_document(crash_report)
             try:
                 index = search.Index(name=__INDEX__)
                 index.put(document)
             except Search.Error:
                 logging.exception('Unable to add document to index')
+
+    @classmethod
+    def add_crash_reports(cls, crash_reports):
+        if crash_reports:
+            documents = [Search.crash_report_to_document(crash_report) for crash_report in crash_reports]
+            try:
+                index = search.Index(name=__INDEX__)
+                index.put(documents)
+            except Search.Error:
+                logging.exception('Unable to add documents to index')
 
     @classmethod
     def search(cls, query):

--- a/search_model.py
+++ b/search_model.py
@@ -34,7 +34,7 @@ class Search(object):
         labels = [search.TextField(name='labels', value=label)
                   for label in crash_report.labels]
         fields.extend(labels)
-        document = search.Document(doc_id=crash_report.name, fields=fields)
+        document = search.Document(doc_id=unicode(crash_report.key()), fields=fields)
         return document
 
     @classmethod
@@ -44,8 +44,8 @@ class Search(object):
             try:
                 index = search.Index(name=__INDEX__)
                 index.put(document)
-            except Search.Error:
-                logging.exception('Unable to add document to index')
+            except search.Error, e:
+                logging.exception('Unable to add document to index', e)
 
     @classmethod
     def add_crash_reports(cls, crash_reports):
@@ -54,8 +54,8 @@ class Search(object):
             try:
                 index = search.Index(name=__INDEX__)
                 index.put(documents)
-            except Search.Error:
-                logging.exception('Unable to add documents to index')
+            except search.Error, e:
+                logging.exception('Unable to add documents to index', e)
 
     @classmethod
     def search(cls, query):

--- a/update_schema.py
+++ b/update_schema.py
@@ -7,7 +7,7 @@ from google.appengine.ext import deferred
 from model import CrashReport
 from search_model import Search
 
-BATCH_SIZE = 100
+BATCH_SIZE = 25
 
 
 class SchemaUpdater(object):
@@ -21,24 +21,18 @@ class SchemaUpdater(object):
         if cursor:
             query.with_cursor(cursor)
 
-        crash_reports = []
+        crash_reports = list()
         for crash_report in query.fetch(limit=BATCH_SIZE):
-            updated = False
-            if not crash_report.version:
-                crash_report.version = '2'
-                updated = True
-            if not crash_report.state:
-                crash_report.state = 'unresolved'
-                updated = True
-            if updated:
-                crash_reports.append(crash_report)
+            crash_report.version = '2'
+            crash_report.state = 'unresolved'
+            crash_reports.append(crash_report)
 
         if crash_reports:
             updated = len(crash_reports)
             logging.info('Updating %s entities', updated)
             # update
             db.put(crash_reports)
-            Search.add_crash_reports(crash_reports)
+            [Search.add_to_index(crash_report) for crash_report in crash_reports]
             # schedule next request
             deferred.defer(SchemaUpdater.update, cursor=query.cursor())
 

--- a/update_schema.py
+++ b/update_schema.py
@@ -23,8 +23,15 @@ class SchemaUpdater(object):
 
         crash_reports = []
         for crash_report in query.fetch(limit=BATCH_SIZE):
-            crash_report.state = 'unresolved'
-            crash_reports.append(crash_report)
+            updated = False
+            if not crash_report.version:
+                crash_report.version = '2'
+                updated = True
+            if not crash_report.state:
+                crash_report.state = 'unresolved'
+                updated = True
+            if updated:
+                crash_reports.append(crash_report)
 
         if crash_reports:
             updated = len(crash_reports)

--- a/update_schema.py
+++ b/update_schema.py
@@ -1,0 +1,44 @@
+import logging
+
+import webapp2
+from google.appengine.ext import db
+from google.appengine.ext import deferred
+
+from model import CrashReport
+from search_model import Search
+
+BATCH_SIZE = 100
+
+
+class SchemaUpdater(object):
+    """
+    Updates the crash reporter schema. Adds the state on the crash reporter.
+    """
+    @classmethod
+    def update(cls, cursor=None):
+        logging.info('Upgrading schema for Crash Reports (Cursor = %s)' % unicode(cursor))
+        query = CrashReport.all()
+        if cursor:
+            query.with_cursor(cursor)
+
+        crash_reports = []
+        for crash_report in query.fetch(limit=BATCH_SIZE):
+            crash_report.state = 'unresolved'
+            crash_reports.append(crash_report)
+
+        if crash_reports:
+            updated = len(crash_reports)
+            logging.info('Updating %s entities', updated)
+            # update
+            db.put(crash_reports)
+            Search.add_crash_reports(crash_reports)
+            # schedule next request
+            deferred.defer(SchemaUpdater.update, cursor=query.cursor())
+
+
+class UpdateSchemaHandler(webapp2.RequestHandler):
+    def get(self):
+        deferred.defer(SchemaUpdater.update)
+        message = 'Schema Updates Started'
+        logging.info(message)
+        self.response.out.write(message)

--- a/update_schema.py
+++ b/update_schema.py
@@ -7,13 +7,18 @@ from google.appengine.ext import deferred
 from model import CrashReport
 from search_model import Search
 
-BATCH_SIZE = 25
+BATCH_SIZE = 100
 
 
 class SchemaUpdater(object):
     """
     Updates the crash reporter schema. Adds the state on the crash reporter.
     """
+    @classmethod
+    def delete_search_indexes(cls):
+        logging.info("Deleting all entries from Search Indexes.")
+        Search.delete_all_in_index()
+
     @classmethod
     def update(cls, cursor=None):
         logging.info('Upgrading schema for Crash Reports (Cursor = %s)' % unicode(cursor))
@@ -32,9 +37,17 @@ class SchemaUpdater(object):
             logging.info('Updating %s entities', updated)
             # update
             db.put(crash_reports)
-            [Search.add_to_index(crash_report) for crash_report in crash_reports]
+            Search.add_crash_reports(crash_reports)
             # schedule next request
             deferred.defer(SchemaUpdater.update, cursor=query.cursor())
+
+
+class RemoveSearchIndexes(webapp2.RequestHandler):
+    def get(self):
+        deferred.defer(SchemaUpdater.delete_search_indexes)
+        message = 'Removing all search indexes started'
+        logging.info(message)
+        self.response.out.write(message)
 
 
 class UpdateSchemaHandler(webapp2.RequestHandler):

--- a/util.py
+++ b/util.py
@@ -61,9 +61,7 @@ class CrashReports(object):
     def trending(cls, start=None, limit=20):
         q = CrashReport.all()
         # only search for crashes that are not resolved
-        q.filter('state = ', 'unresolved')
-        q.filter('state = ', 'pending')
-        q.filter('state = ', 'submitted')
+        q.filter('state IN ', ['unresolved', 'pending', 'submitted'])
 
         if start:
             q.filter('__key__ >', Key(start))

--- a/util.py
+++ b/util.py
@@ -60,8 +60,11 @@ class CrashReports(object):
     @classmethod
     def trending(cls, start=None, limit=20):
         q = CrashReport.all()
-        # only search for unresolved crashes
+        # only search for crashes that are not resolved
         q.filter('state = ', 'unresolved')
+        q.filter('state = ', 'pending')
+        q.filter('state = ', 'submitted')
+
         if start:
             q.filter('__key__ >', Key(start))
         q.order('__key__')


### PR DESCRIPTION
-  `state` can be one of `unresolved`, `pending`, `submitted`, `resolved`.
  -  `unresolved` typically refers to a newly un-triaged report.
  -  `pending` typically refers to a newly triaged report where investigation is in progress.
  -  `submitted` refers to a crash report for which a fix has been submitted.
  -  `resolved` refers to a crash report for which the fix has been verified.
- Crash reports that have been `resolved` will no longer appear in `Trending reports` page.
- Also added a schema on the entities in the datastore, to make migration easier.
- More elegant handing of entities in the datastore and cache and search indexes.
- Added support for schema migration with Task Queues.
