### PR TITLE
Add a fully qualified URL to the crash reporter in the README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -3,7 +3,9 @@
 This project helps collect [Tessel 2](https://tessel.io/) CLI crash reports,
 and makes them easily accessible and searchable.
 
+## URL
 
+The crash reporter is available [here](http://crash-reporter.tessel.io/).
 
 
 


### PR DESCRIPTION
Fixes https://github.com/tessel/t2-crash-reporter/issues/8
