### PR TITLE
Add support for GitHub integration.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+client_secrets.json
 ._DS_Store
 .DS_Store
 *.pyc

--- a/client_secrets.json
+++ b/client_secrets.json
@@ -1,0 +1,3 @@
+{
+  "github_token": "6f05c59e7ec51b4a08123d67be3d29ffb3e1ccb4"
+}

--- a/client_secrets.json
+++ b/client_secrets.json
@@ -1,3 +1,0 @@
-{
-  "github_token": "6f05c59e7ec51b4a08123d67be3d29ffb3e1ccb4"
-}

--- a/common.py
+++ b/common.py
@@ -1,8 +1,9 @@
-from google.appengine.api import memcache
-import os
-import logging
 import json
+import logging
+import os
+
 import jinja2
+from google.appengine.api import memcache
 
 from model import from_milliseconds
 from util import crash_uri, snippetize

--- a/common.py
+++ b/common.py
@@ -6,6 +6,7 @@ import jinja2
 from google.appengine.api import memcache
 
 from model import from_milliseconds
+from github_utils import issue_url
 from util import crash_uri, snippetize
 
 
@@ -62,6 +63,7 @@ class RRequest(object):
             RRequest.environment.filters['readable_date'] = readable_date
             RRequest.environment.filters['crash_uri'] = crash_uri
             RRequest.environment.filters['snippetize'] = snippetize
+            RRequest.environment.filters['issue_url'] = issue_url
 
         return RRequest.environment
 

--- a/github/AuthenticatedUser.py
+++ b/github/AuthenticatedUser.py
@@ -1,0 +1,1158 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Steve English <steve.english@navetas.com>                     #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import datetime
+
+import github.GithubObject
+import github.PaginatedList
+
+import github.Gist
+import github.Repository
+import github.NamedUser
+import github.Plan
+import github.Organization
+import github.UserKey
+import github.Issue
+import github.Event
+import github.Authorization
+import github.Notification
+
+
+class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
+    """
+    This class represents AuthenticatedUsers as returned for example by http://developer.github.com/v3/todo
+    """
+
+    @property
+    def avatar_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._avatar_url)
+        return self._avatar_url.value
+
+    @property
+    def bio(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._bio)
+        return self._bio.value
+
+    @property
+    def blog(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._blog)
+        return self._blog.value
+
+    @property
+    def collaborators(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._collaborators)
+        return self._collaborators.value
+
+    @property
+    def company(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._company)
+        return self._company.value
+
+    @property
+    def created_at(self):
+        """
+        :type: datetime.datetime
+        """
+        self._completeIfNotSet(self._created_at)
+        return self._created_at.value
+
+    @property
+    def disk_usage(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._disk_usage)
+        return self._disk_usage.value
+
+    @property
+    def email(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._email)
+        return self._email.value
+
+    @property
+    def events_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._events_url)
+        return self._events_url.value
+
+    @property
+    def followers(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._followers)
+        return self._followers.value
+
+    @property
+    def followers_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._followers_url)
+        return self._followers_url.value
+
+    @property
+    def following(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._following)
+        return self._following.value
+
+    @property
+    def following_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._following_url)
+        return self._following_url.value
+
+    @property
+    def gists_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._gists_url)
+        return self._gists_url.value
+
+    @property
+    def gravatar_id(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._gravatar_id)
+        return self._gravatar_id.value
+
+    @property
+    def hireable(self):
+        """
+        :type: bool
+        """
+        self._completeIfNotSet(self._hireable)
+        return self._hireable.value
+
+    @property
+    def html_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._html_url)
+        return self._html_url.value
+
+    @property
+    def id(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._id)
+        return self._id.value
+
+    @property
+    def location(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._location)
+        return self._location.value
+
+    @property
+    def login(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._login)
+        return self._login.value
+
+    @property
+    def name(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._name)
+        return self._name.value
+
+    @property
+    def organizations_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._organizations_url)
+        return self._organizations_url.value
+
+    @property
+    def owned_private_repos(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._owned_private_repos)
+        return self._owned_private_repos.value
+
+    @property
+    def plan(self):
+        """
+        :type: :class:`github.Plan.Plan`
+        """
+        self._completeIfNotSet(self._plan)
+        return self._plan.value
+
+    @property
+    def private_gists(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._private_gists)
+        return self._private_gists.value
+
+    @property
+    def public_gists(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._public_gists)
+        return self._public_gists.value
+
+    @property
+    def public_repos(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._public_repos)
+        return self._public_repos.value
+
+    @property
+    def received_events_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._received_events_url)
+        return self._received_events_url.value
+
+    @property
+    def repos_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._repos_url)
+        return self._repos_url.value
+
+    @property
+    def site_admin(self):
+        """
+        :type: bool
+        """
+        self._completeIfNotSet(self._site_admin)
+        return self._site_admin.value
+
+    @property
+    def starred_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._starred_url)
+        return self._starred_url.value
+
+    @property
+    def subscriptions_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._subscriptions_url)
+        return self._subscriptions_url.value
+
+    @property
+    def total_private_repos(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._total_private_repos)
+        return self._total_private_repos.value
+
+    @property
+    def type(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._type)
+        return self._type.value
+
+    @property
+    def updated_at(self):
+        """
+        :type: datetime.datetime
+        """
+        self._completeIfNotSet(self._updated_at)
+        return self._updated_at.value
+
+    @property
+    def url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._url)
+        return self._url.value
+
+    def add_to_emails(self, *emails):
+        """
+        :calls: `POST /user/emails <http://developer.github.com/v3/users/emails>`_
+        :param email: string
+        :rtype: None
+        """
+        assert all(isinstance(element, (str, unicode)) for element in emails), emails
+        post_parameters = emails
+        headers, data = self._requester.requestJsonAndCheck(
+            "POST",
+            "/user/emails",
+            input=post_parameters
+        )
+
+    def add_to_following(self, following):
+        """
+        :calls: `PUT /user/following/:user <http://developer.github.com/v3/users/followers>`_
+        :param following: :class:`github.NamedUser.NamedUser`
+        :rtype: None
+        """
+        assert isinstance(following, github.NamedUser.NamedUser), following
+        headers, data = self._requester.requestJsonAndCheck(
+            "PUT",
+            "/user/following/" + following._identity
+        )
+
+    def add_to_starred(self, starred):
+        """
+        :calls: `PUT /user/starred/:owner/:repo <http://developer.github.com/v3/activity/starring>`_
+        :param starred: :class:`github.Repository.Repository`
+        :rtype: None
+        """
+        assert isinstance(starred, github.Repository.Repository), starred
+        headers, data = self._requester.requestJsonAndCheck(
+            "PUT",
+            "/user/starred/" + starred._identity
+        )
+
+    def add_to_subscriptions(self, subscription):
+        """
+        :calls: `PUT /user/subscriptions/:owner/:repo <http://developer.github.com/v3/activity/watching>`_
+        :param subscription: :class:`github.Repository.Repository`
+        :rtype: None
+        """
+        assert isinstance(subscription, github.Repository.Repository), subscription
+        headers, data = self._requester.requestJsonAndCheck(
+            "PUT",
+            "/user/subscriptions/" + subscription._identity
+        )
+
+    def add_to_watched(self, watched):
+        """
+        :calls: `PUT /user/watched/:owner/:repo <http://developer.github.com/v3/activity/starring>`_
+        :param watched: :class:`github.Repository.Repository`
+        :rtype: None
+        """
+        assert isinstance(watched, github.Repository.Repository), watched
+        headers, data = self._requester.requestJsonAndCheck(
+            "PUT",
+            "/user/watched/" + watched._identity
+        )
+
+    def create_authorization(self, scopes=github.GithubObject.NotSet, note=github.GithubObject.NotSet, note_url=github.GithubObject.NotSet, client_id=github.GithubObject.NotSet, client_secret=github.GithubObject.NotSet, onetime_password=None):
+        """
+        :calls: `POST /authorizations <http://developer.github.com/v3/oauth>`_
+        :param scopes: list of string
+        :param note: string
+        :param note_url: string
+        :param client_id: string
+        :param client_secret: string
+        :param onetime_password: string
+        :rtype: :class:`github.Authorization.Authorization`
+        """
+        assert scopes is github.GithubObject.NotSet or all(isinstance(element, (str, unicode)) for element in scopes), scopes
+        assert note is github.GithubObject.NotSet or isinstance(note, (str, unicode)), note
+        assert note_url is github.GithubObject.NotSet or isinstance(note_url, (str, unicode)), note_url
+        assert client_id is github.GithubObject.NotSet or isinstance(client_id, (str, unicode)), client_id
+        assert client_secret is github.GithubObject.NotSet or isinstance(client_secret, (str, unicode)), client_secret
+        assert onetime_password is None or isinstance(onetime_password, (str, unicode)), onetime_password
+        post_parameters = dict()
+        if scopes is not github.GithubObject.NotSet:
+            post_parameters["scopes"] = scopes
+        if note is not github.GithubObject.NotSet:
+            post_parameters["note"] = note
+        if note_url is not github.GithubObject.NotSet:
+            post_parameters["note_url"] = note_url
+        if client_id is not github.GithubObject.NotSet:
+            post_parameters["client_id"] = client_id
+        if client_secret is not github.GithubObject.NotSet:
+            post_parameters["client_secret"] = client_secret
+        if onetime_password is not None:
+            request_header = {'X-GitHub-OTP': onetime_password}  # pragma no cover (Should be covered)
+        else:
+            request_header = None
+        headers, data = self._requester.requestJsonAndCheck(
+            "POST",
+            "/authorizations",
+            input=post_parameters,
+            headers=request_header,
+        )
+        return github.Authorization.Authorization(self._requester, headers, data, completed=True)
+
+    def create_fork(self, repo):
+        """
+        :calls: `POST /repos/:owner/:repo/forks <http://developer.github.com/v3/repos/forks>`_
+        :param repo: :class:`github.Repository.Repository`
+        :rtype: :class:`github.Repository.Repository`
+        """
+        assert isinstance(repo, github.Repository.Repository), repo
+        headers, data = self._requester.requestJsonAndCheck(
+            "POST",
+            "/repos/" + repo.owner.login + "/" + repo.name + "/forks"
+        )
+        return github.Repository.Repository(self._requester, headers, data, completed=True)
+
+    def create_gist(self, public, files, description=github.GithubObject.NotSet):
+        """
+        :calls: `POST /gists <http://developer.github.com/v3/gists>`_
+        :param public: bool
+        :param files: dict of string to :class:`github.InputFileContent.InputFileContent`
+        :param description: string
+        :rtype: :class:`github.Gist.Gist`
+        """
+        assert isinstance(public, bool), public
+        assert all(isinstance(element, github.InputFileContent) for element in files.itervalues()), files
+        assert description is github.GithubObject.NotSet or isinstance(description, (str, unicode)), description
+        post_parameters = {
+            "public": public,
+            "files": dict((key, value._identity) for key, value in files.iteritems()),
+        }
+        if description is not github.GithubObject.NotSet:
+            post_parameters["description"] = description
+        headers, data = self._requester.requestJsonAndCheck(
+            "POST",
+            "/gists",
+            input=post_parameters
+        )
+        return github.Gist.Gist(self._requester, headers, data, completed=True)
+
+    def create_key(self, title, key):
+        """
+        :calls: `POST /user/keys <http://developer.github.com/v3/users/keys>`_
+        :param title: string
+        :param key: string
+        :rtype: :class:`github.UserKey.UserKey`
+        """
+        assert isinstance(title, (str, unicode)), title
+        assert isinstance(key, (str, unicode)), key
+        post_parameters = {
+            "title": title,
+            "key": key,
+        }
+        headers, data = self._requester.requestJsonAndCheck(
+            "POST",
+            "/user/keys",
+            input=post_parameters
+        )
+        return github.UserKey.UserKey(self._requester, headers, data, completed=True)
+
+    def create_repo(self, name, description=github.GithubObject.NotSet, homepage=github.GithubObject.NotSet, private=github.GithubObject.NotSet, has_issues=github.GithubObject.NotSet, has_wiki=github.GithubObject.NotSet, has_downloads=github.GithubObject.NotSet, auto_init=github.GithubObject.NotSet, gitignore_template=github.GithubObject.NotSet):
+        """
+        :calls: `POST /user/repos <http://developer.github.com/v3/repos>`_
+        :param name: string
+        :param description: string
+        :param homepage: string
+        :param private: bool
+        :param has_issues: bool
+        :param has_wiki: bool
+        :param has_downloads: bool
+        :param auto_init: bool
+        :param gitignore_template: string
+        :rtype: :class:`github.Repository.Repository`
+        """
+        assert isinstance(name, (str, unicode)), name
+        assert description is github.GithubObject.NotSet or isinstance(description, (str, unicode)), description
+        assert homepage is github.GithubObject.NotSet or isinstance(homepage, (str, unicode)), homepage
+        assert private is github.GithubObject.NotSet or isinstance(private, bool), private
+        assert has_issues is github.GithubObject.NotSet or isinstance(has_issues, bool), has_issues
+        assert has_wiki is github.GithubObject.NotSet or isinstance(has_wiki, bool), has_wiki
+        assert has_downloads is github.GithubObject.NotSet or isinstance(has_downloads, bool), has_downloads
+        assert auto_init is github.GithubObject.NotSet or isinstance(auto_init, bool), auto_init
+        assert gitignore_template is github.GithubObject.NotSet or isinstance(gitignore_template, (str, unicode)), gitignore_template
+        post_parameters = {
+            "name": name,
+        }
+        if description is not github.GithubObject.NotSet:
+            post_parameters["description"] = description
+        if homepage is not github.GithubObject.NotSet:
+            post_parameters["homepage"] = homepage
+        if private is not github.GithubObject.NotSet:
+            post_parameters["private"] = private
+        if has_issues is not github.GithubObject.NotSet:
+            post_parameters["has_issues"] = has_issues
+        if has_wiki is not github.GithubObject.NotSet:
+            post_parameters["has_wiki"] = has_wiki
+        if has_downloads is not github.GithubObject.NotSet:
+            post_parameters["has_downloads"] = has_downloads
+        if auto_init is not github.GithubObject.NotSet:
+            post_parameters["auto_init"] = auto_init
+        if gitignore_template is not github.GithubObject.NotSet:
+            post_parameters["gitignore_template"] = gitignore_template
+        headers, data = self._requester.requestJsonAndCheck(
+            "POST",
+            "/user/repos",
+            input=post_parameters
+        )
+        return github.Repository.Repository(self._requester, headers, data, completed=True)
+
+    def edit(self, name=github.GithubObject.NotSet, email=github.GithubObject.NotSet, blog=github.GithubObject.NotSet, company=github.GithubObject.NotSet, location=github.GithubObject.NotSet, hireable=github.GithubObject.NotSet, bio=github.GithubObject.NotSet):
+        """
+        :calls: `PATCH /user <http://developer.github.com/v3/users>`_
+        :param name: string
+        :param email: string
+        :param blog: string
+        :param company: string
+        :param location: string
+        :param hireable: bool
+        :param bio: string
+        :rtype: None
+        """
+        assert name is github.GithubObject.NotSet or isinstance(name, (str, unicode)), name
+        assert email is github.GithubObject.NotSet or isinstance(email, (str, unicode)), email
+        assert blog is github.GithubObject.NotSet or isinstance(blog, (str, unicode)), blog
+        assert company is github.GithubObject.NotSet or isinstance(company, (str, unicode)), company
+        assert location is github.GithubObject.NotSet or isinstance(location, (str, unicode)), location
+        assert hireable is github.GithubObject.NotSet or isinstance(hireable, bool), hireable
+        assert bio is github.GithubObject.NotSet or isinstance(bio, (str, unicode)), bio
+        post_parameters = dict()
+        if name is not github.GithubObject.NotSet:
+            post_parameters["name"] = name
+        if email is not github.GithubObject.NotSet:
+            post_parameters["email"] = email
+        if blog is not github.GithubObject.NotSet:
+            post_parameters["blog"] = blog
+        if company is not github.GithubObject.NotSet:
+            post_parameters["company"] = company
+        if location is not github.GithubObject.NotSet:
+            post_parameters["location"] = location
+        if hireable is not github.GithubObject.NotSet:
+            post_parameters["hireable"] = hireable
+        if bio is not github.GithubObject.NotSet:
+            post_parameters["bio"] = bio
+        headers, data = self._requester.requestJsonAndCheck(
+            "PATCH",
+            "/user",
+            input=post_parameters
+        )
+        self._useAttributes(data)
+
+    def get_authorization(self, id):
+        """
+        :calls: `GET /authorizations/:id <http://developer.github.com/v3/oauth>`_
+        :param id: integer
+        :rtype: :class:`github.Authorization.Authorization`
+        """
+        assert isinstance(id, (int, long)), id
+        headers, data = self._requester.requestJsonAndCheck(
+            "GET",
+            "/authorizations/" + str(id)
+        )
+        return github.Authorization.Authorization(self._requester, headers, data, completed=True)
+
+    def get_authorizations(self):
+        """
+        :calls: `GET /authorizations <http://developer.github.com/v3/oauth>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Authorization.Authorization`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.Authorization.Authorization,
+            self._requester,
+            "/authorizations",
+            None
+        )
+
+    def get_emails(self):
+        """
+        :calls: `GET /user/emails <http://developer.github.com/v3/users/emails>`_
+        :rtype: list of string
+        """
+        headers, data = self._requester.requestJsonAndCheck(
+            "GET",
+            "/user/emails"
+        )
+        return data
+
+    def get_events(self):
+        """
+        :calls: `GET /events <http://developer.github.com/v3/activity/events>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Event.Event`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.Event.Event,
+            self._requester,
+            "/events",
+            None
+        )
+
+    def get_followers(self):
+        """
+        :calls: `GET /user/followers <http://developer.github.com/v3/users/followers>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.NamedUser.NamedUser`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.NamedUser.NamedUser,
+            self._requester,
+            "/user/followers",
+            None
+        )
+
+    def get_following(self):
+        """
+        :calls: `GET /user/following <http://developer.github.com/v3/users/followers>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.NamedUser.NamedUser`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.NamedUser.NamedUser,
+            self._requester,
+            "/user/following",
+            None
+        )
+
+    def get_gists(self):
+        """
+        :calls: `GET /gists <http://developer.github.com/v3/gists>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Gist.Gist`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.Gist.Gist,
+            self._requester,
+            "/gists",
+            None
+        )
+
+    def get_issues(self, filter=github.GithubObject.NotSet, state=github.GithubObject.NotSet, labels=github.GithubObject.NotSet, sort=github.GithubObject.NotSet, direction=github.GithubObject.NotSet, since=github.GithubObject.NotSet):
+        """
+        :calls: `GET /issues <http://developer.github.com/v3/issues>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Issue.Issue`
+        :param filter: string
+        :param state: string
+        :param labels: list of :class:`github.Label.Label`
+        :param sort: string
+        :param direction: string
+        :param since: datetime.datetime
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Issue.Issue`
+        """
+        assert filter is github.GithubObject.NotSet or isinstance(filter, (str, unicode)), filter
+        assert state is github.GithubObject.NotSet or isinstance(state, (str, unicode)), state
+        assert labels is github.GithubObject.NotSet or all(isinstance(element, github.Label.Label) for element in labels), labels
+        assert sort is github.GithubObject.NotSet or isinstance(sort, (str, unicode)), sort
+        assert direction is github.GithubObject.NotSet or isinstance(direction, (str, unicode)), direction
+        assert since is github.GithubObject.NotSet or isinstance(since, datetime.datetime), since
+        url_parameters = dict()
+        if filter is not github.GithubObject.NotSet:
+            url_parameters["filter"] = filter
+        if state is not github.GithubObject.NotSet:
+            url_parameters["state"] = state
+        if labels is not github.GithubObject.NotSet:
+            url_parameters["labels"] = ",".join(label.name for label in labels)
+        if sort is not github.GithubObject.NotSet:
+            url_parameters["sort"] = sort
+        if direction is not github.GithubObject.NotSet:
+            url_parameters["direction"] = direction
+        if since is not github.GithubObject.NotSet:
+            url_parameters["since"] = since.strftime("%Y-%m-%dT%H:%M:%SZ")
+        return github.PaginatedList.PaginatedList(
+            github.Issue.Issue,
+            self._requester,
+            "/issues",
+            url_parameters
+        )
+
+    def get_user_issues(self, filter=github.GithubObject.NotSet, state=github.GithubObject.NotSet, labels=github.GithubObject.NotSet, sort=github.GithubObject.NotSet, direction=github.GithubObject.NotSet, since=github.GithubObject.NotSet):
+        """
+        :calls: `GET /user/issues <http://developer.github.com/v3/issues>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Issue.Issue`
+        :param filter: string
+        :param state: string
+        :param labels: list of :class:`github.Label.Label`
+        :param sort: string
+        :param direction: string
+        :param since: datetime.datetime
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Issue.Issue`
+        """
+        assert filter is github.GithubObject.NotSet or isinstance(filter, (str, unicode)), filter
+        assert state is github.GithubObject.NotSet or isinstance(state, (str, unicode)), state
+        assert labels is github.GithubObject.NotSet or all(isinstance(element, github.Label.Label) for element in labels), labels
+        assert sort is github.GithubObject.NotSet or isinstance(sort, (str, unicode)), sort
+        assert direction is github.GithubObject.NotSet or isinstance(direction, (str, unicode)), direction
+        assert since is github.GithubObject.NotSet or isinstance(since, datetime.datetime), since
+        url_parameters = dict()
+        if filter is not github.GithubObject.NotSet:
+            url_parameters["filter"] = filter
+        if state is not github.GithubObject.NotSet:
+            url_parameters["state"] = state
+        if labels is not github.GithubObject.NotSet:
+            url_parameters["labels"] = ",".join(label.name for label in labels)
+        if sort is not github.GithubObject.NotSet:
+            url_parameters["sort"] = sort
+        if direction is not github.GithubObject.NotSet:
+            url_parameters["direction"] = direction
+        if since is not github.GithubObject.NotSet:
+            url_parameters["since"] = since.strftime("%Y-%m-%dT%H:%M:%SZ")
+        return github.PaginatedList.PaginatedList(
+            github.Issue.Issue,
+            self._requester,
+            "/issues",
+            url_parameters
+        )
+
+    def get_key(self, id):
+        """
+        :calls: `GET /user/keys/:id <http://developer.github.com/v3/users/keys>`_
+        :param id: integer
+        :rtype: :class:`github.UserKey.UserKey`
+        """
+        assert isinstance(id, (int, long)), id
+        headers, data = self._requester.requestJsonAndCheck(
+            "GET",
+            "/user/keys/" + str(id)
+        )
+        return github.UserKey.UserKey(self._requester, headers, data, completed=True)
+
+    def get_keys(self):
+        """
+        :calls: `GET /user/keys <http://developer.github.com/v3/users/keys>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.UserKey.UserKey`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.UserKey.UserKey,
+            self._requester,
+            "/user/keys",
+            None
+        )
+
+    def get_notification(self, id):
+        """
+        :calls: `GET /notifications/threads/:id <http://developer.github.com/v3/activity/notifications>`_
+        :rtype: :class:`github.Notification.Notification`
+        """
+
+        assert isinstance(id, (str, unicode)), id
+        headers, data = self._requester.requestJsonAndCheck(
+            "GET",
+            "/notifications/threads/" + id
+        )
+        return github.Notification.Notification(self._requester, headers, data, completed=True)
+
+    def get_notifications(self, all=github.GithubObject.NotSet, participating=github.GithubObject.NotSet):
+        """
+        :calls: `GET /notifications <http://developer.github.com/v3/activity/notifications>`_
+        :param all: bool
+        :param participating: bool
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Notification.Notification`
+        """
+
+        assert all is github.GithubObject.NotSet or isinstance(all, bool), all
+        assert participating is github.GithubObject.NotSet or isinstance(participating, bool), participating
+
+        params = dict()
+        if all is not github.GithubObject.NotSet:
+            params["all"] = all
+        if participating is not github.GithubObject.NotSet:
+            params["participating"] = participating
+        # TODO: implement parameter "since"
+
+        return github.PaginatedList.PaginatedList(
+            github.Notification.Notification,
+            self._requester,
+            "/notifications",
+            params
+        )
+
+    def get_organization_events(self, org):
+        """
+        :calls: `GET /users/:user/events/orgs/:org <http://developer.github.com/v3/activity/events>`_
+        :param org: :class:`github.Organization.Organization`
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Event.Event`
+        """
+        assert isinstance(org, github.Organization.Organization), org
+        return github.PaginatedList.PaginatedList(
+            github.Event.Event,
+            self._requester,
+            "/users/" + self.login + "/events/orgs/" + org.login,
+            None
+        )
+
+    def get_orgs(self):
+        """
+        :calls: `GET /user/orgs <http://developer.github.com/v3/orgs>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Organization.Organization`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.Organization.Organization,
+            self._requester,
+            "/user/orgs",
+            None
+        )
+
+    def get_repo(self, name):
+        """
+        :calls: `GET /repos/:owner/:repo <http://developer.github.com/v3/repos>`_
+        :param name: string
+        :rtype: :class:`github.Repository.Repository`
+        """
+        assert isinstance(name, (str, unicode)), name
+        headers, data = self._requester.requestJsonAndCheck(
+            "GET",
+            "/repos/" + self.login + "/" + name
+        )
+        return github.Repository.Repository(self._requester, headers, data, completed=True)
+
+    def get_repos(self, type=github.GithubObject.NotSet, sort=github.GithubObject.NotSet, direction=github.GithubObject.NotSet):
+        """
+        :calls: `GET /user/repos <http://developer.github.com/v3/repos>`_
+        :param type: string
+        :param sort: string
+        :param direction: string
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Repository.Repository`
+        """
+        assert type is github.GithubObject.NotSet or isinstance(type, (str, unicode)), type
+        assert sort is github.GithubObject.NotSet or isinstance(sort, (str, unicode)), sort
+        assert direction is github.GithubObject.NotSet or isinstance(direction, (str, unicode)), direction
+        url_parameters = dict()
+        if type is not github.GithubObject.NotSet:
+            url_parameters["type"] = type
+        if sort is not github.GithubObject.NotSet:
+            url_parameters["sort"] = sort
+        if direction is not github.GithubObject.NotSet:
+            url_parameters["direction"] = direction
+        return github.PaginatedList.PaginatedList(
+            github.Repository.Repository,
+            self._requester,
+            "/user/repos",
+            url_parameters
+        )
+
+    def get_starred(self):
+        """
+        :calls: `GET /user/starred <http://developer.github.com/v3/activity/starring>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Repository.Repository`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.Repository.Repository,
+            self._requester,
+            "/user/starred",
+            None
+        )
+
+    def get_starred_gists(self):
+        """
+        :calls: `GET /gists/starred <http://developer.github.com/v3/gists>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Gist.Gist`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.Gist.Gist,
+            self._requester,
+            "/gists/starred",
+            None
+        )
+
+    def get_subscriptions(self):
+        """
+        :calls: `GET /user/subscriptions <http://developer.github.com/v3/activity/watching>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Repository.Repository`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.Repository.Repository,
+            self._requester,
+            "/user/subscriptions",
+            None
+        )
+
+    def get_teams(self):
+        """
+        :calls: `GET /user/teams <http://developer.github.com/v3/orgs/teams>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Team.Team`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.Team.Team,
+            self._requester,
+            "/user/teams",
+            None
+        )
+
+    def get_watched(self):
+        """
+        :calls: `GET /user/watched <http://developer.github.com/v3/activity/starring>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Repository.Repository`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.Repository.Repository,
+            self._requester,
+            "/user/watched",
+            None
+        )
+
+    def has_in_following(self, following):
+        """
+        :calls: `GET /user/following/:user <http://developer.github.com/v3/users/followers>`_
+        :param following: :class:`github.NamedUser.NamedUser`
+        :rtype: bool
+        """
+        assert isinstance(following, github.NamedUser.NamedUser), following
+        status, headers, data = self._requester.requestJson(
+            "GET",
+            "/user/following/" + following._identity
+        )
+        return status == 204
+
+    def has_in_starred(self, starred):
+        """
+        :calls: `GET /user/starred/:owner/:repo <http://developer.github.com/v3/activity/starring>`_
+        :param starred: :class:`github.Repository.Repository`
+        :rtype: bool
+        """
+        assert isinstance(starred, github.Repository.Repository), starred
+        status, headers, data = self._requester.requestJson(
+            "GET",
+            "/user/starred/" + starred._identity
+        )
+        return status == 204
+
+    def has_in_subscriptions(self, subscription):
+        """
+        :calls: `GET /user/subscriptions/:owner/:repo <http://developer.github.com/v3/activity/watching>`_
+        :param subscription: :class:`github.Repository.Repository`
+        :rtype: bool
+        """
+        assert isinstance(subscription, github.Repository.Repository), subscription
+        status, headers, data = self._requester.requestJson(
+            "GET",
+            "/user/subscriptions/" + subscription._identity
+        )
+        return status == 204
+
+    def has_in_watched(self, watched):
+        """
+        :calls: `GET /user/watched/:owner/:repo <http://developer.github.com/v3/activity/starring>`_
+        :param watched: :class:`github.Repository.Repository`
+        :rtype: bool
+        """
+        assert isinstance(watched, github.Repository.Repository), watched
+        status, headers, data = self._requester.requestJson(
+            "GET",
+            "/user/watched/" + watched._identity
+        )
+        return status == 204
+
+    def remove_from_emails(self, *emails):
+        """
+        :calls: `DELETE /user/emails <http://developer.github.com/v3/users/emails>`_
+        :param email: string
+        :rtype: None
+        """
+        assert all(isinstance(element, (str, unicode)) for element in emails), emails
+        post_parameters = emails
+        headers, data = self._requester.requestJsonAndCheck(
+            "DELETE",
+            "/user/emails",
+            input=post_parameters
+        )
+
+    def remove_from_following(self, following):
+        """
+        :calls: `DELETE /user/following/:user <http://developer.github.com/v3/users/followers>`_
+        :param following: :class:`github.NamedUser.NamedUser`
+        :rtype: None
+        """
+        assert isinstance(following, github.NamedUser.NamedUser), following
+        headers, data = self._requester.requestJsonAndCheck(
+            "DELETE",
+            "/user/following/" + following._identity
+        )
+
+    def remove_from_starred(self, starred):
+        """
+        :calls: `DELETE /user/starred/:owner/:repo <http://developer.github.com/v3/activity/starring>`_
+        :param starred: :class:`github.Repository.Repository`
+        :rtype: None
+        """
+        assert isinstance(starred, github.Repository.Repository), starred
+        headers, data = self._requester.requestJsonAndCheck(
+            "DELETE",
+            "/user/starred/" + starred._identity
+        )
+
+    def remove_from_subscriptions(self, subscription):
+        """
+        :calls: `DELETE /user/subscriptions/:owner/:repo <http://developer.github.com/v3/activity/watching>`_
+        :param subscription: :class:`github.Repository.Repository`
+        :rtype: None
+        """
+        assert isinstance(subscription, github.Repository.Repository), subscription
+        headers, data = self._requester.requestJsonAndCheck(
+            "DELETE",
+            "/user/subscriptions/" + subscription._identity
+        )
+
+    def remove_from_watched(self, watched):
+        """
+        :calls: `DELETE /user/watched/:owner/:repo <http://developer.github.com/v3/activity/starring>`_
+        :param watched: :class:`github.Repository.Repository`
+        :rtype: None
+        """
+        assert isinstance(watched, github.Repository.Repository), watched
+        headers, data = self._requester.requestJsonAndCheck(
+            "DELETE",
+            "/user/watched/" + watched._identity
+        )
+
+    def _initAttributes(self):
+        self._avatar_url = github.GithubObject.NotSet
+        self._bio = github.GithubObject.NotSet
+        self._blog = github.GithubObject.NotSet
+        self._collaborators = github.GithubObject.NotSet
+        self._company = github.GithubObject.NotSet
+        self._created_at = github.GithubObject.NotSet
+        self._disk_usage = github.GithubObject.NotSet
+        self._email = github.GithubObject.NotSet
+        self._events_url = github.GithubObject.NotSet
+        self._followers = github.GithubObject.NotSet
+        self._followers_url = github.GithubObject.NotSet
+        self._following = github.GithubObject.NotSet
+        self._following_url = github.GithubObject.NotSet
+        self._gists_url = github.GithubObject.NotSet
+        self._gravatar_id = github.GithubObject.NotSet
+        self._hireable = github.GithubObject.NotSet
+        self._html_url = github.GithubObject.NotSet
+        self._id = github.GithubObject.NotSet
+        self._location = github.GithubObject.NotSet
+        self._login = github.GithubObject.NotSet
+        self._name = github.GithubObject.NotSet
+        self._organizations_url = github.GithubObject.NotSet
+        self._owned_private_repos = github.GithubObject.NotSet
+        self._plan = github.GithubObject.NotSet
+        self._private_gists = github.GithubObject.NotSet
+        self._public_gists = github.GithubObject.NotSet
+        self._public_repos = github.GithubObject.NotSet
+        self._received_events_url = github.GithubObject.NotSet
+        self._repos_url = github.GithubObject.NotSet
+        self._site_admin = github.GithubObject.NotSet
+        self._starred_url = github.GithubObject.NotSet
+        self._subscriptions_url = github.GithubObject.NotSet
+        self._total_private_repos = github.GithubObject.NotSet
+        self._type = github.GithubObject.NotSet
+        self._updated_at = github.GithubObject.NotSet
+        self._url = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "avatar_url" in attributes:  # pragma no branch
+            self._avatar_url = self._makeStringAttribute(attributes["avatar_url"])
+        if "bio" in attributes:  # pragma no branch
+            self._bio = self._makeStringAttribute(attributes["bio"])
+        if "blog" in attributes:  # pragma no branch
+            self._blog = self._makeStringAttribute(attributes["blog"])
+        if "collaborators" in attributes:  # pragma no branch
+            self._collaborators = self._makeIntAttribute(attributes["collaborators"])
+        if "company" in attributes:  # pragma no branch
+            self._company = self._makeStringAttribute(attributes["company"])
+        if "created_at" in attributes:  # pragma no branch
+            self._created_at = self._makeDatetimeAttribute(attributes["created_at"])
+        if "disk_usage" in attributes:  # pragma no branch
+            self._disk_usage = self._makeIntAttribute(attributes["disk_usage"])
+        if "email" in attributes:  # pragma no branch
+            self._email = self._makeStringAttribute(attributes["email"])
+        if "events_url" in attributes:  # pragma no branch
+            self._events_url = self._makeStringAttribute(attributes["events_url"])
+        if "followers" in attributes:  # pragma no branch
+            self._followers = self._makeIntAttribute(attributes["followers"])
+        if "followers_url" in attributes:  # pragma no branch
+            self._followers_url = self._makeStringAttribute(attributes["followers_url"])
+        if "following" in attributes:  # pragma no branch
+            self._following = self._makeIntAttribute(attributes["following"])
+        if "following_url" in attributes:  # pragma no branch
+            self._following_url = self._makeStringAttribute(attributes["following_url"])
+        if "gists_url" in attributes:  # pragma no branch
+            self._gists_url = self._makeStringAttribute(attributes["gists_url"])
+        if "gravatar_id" in attributes:  # pragma no branch
+            self._gravatar_id = self._makeStringAttribute(attributes["gravatar_id"])
+        if "hireable" in attributes:  # pragma no branch
+            self._hireable = self._makeBoolAttribute(attributes["hireable"])
+        if "html_url" in attributes:  # pragma no branch
+            self._html_url = self._makeStringAttribute(attributes["html_url"])
+        if "id" in attributes:  # pragma no branch
+            self._id = self._makeIntAttribute(attributes["id"])
+        if "location" in attributes:  # pragma no branch
+            self._location = self._makeStringAttribute(attributes["location"])
+        if "login" in attributes:  # pragma no branch
+            self._login = self._makeStringAttribute(attributes["login"])
+        if "name" in attributes:  # pragma no branch
+            self._name = self._makeStringAttribute(attributes["name"])
+        if "organizations_url" in attributes:  # pragma no branch
+            self._organizations_url = self._makeStringAttribute(attributes["organizations_url"])
+        if "owned_private_repos" in attributes:  # pragma no branch
+            self._owned_private_repos = self._makeIntAttribute(attributes["owned_private_repos"])
+        if "plan" in attributes:  # pragma no branch
+            self._plan = self._makeClassAttribute(github.Plan.Plan, attributes["plan"])
+        if "private_gists" in attributes:  # pragma no branch
+            self._private_gists = self._makeIntAttribute(attributes["private_gists"])
+        if "public_gists" in attributes:  # pragma no branch
+            self._public_gists = self._makeIntAttribute(attributes["public_gists"])
+        if "public_repos" in attributes:  # pragma no branch
+            self._public_repos = self._makeIntAttribute(attributes["public_repos"])
+        if "received_events_url" in attributes:  # pragma no branch
+            self._received_events_url = self._makeStringAttribute(attributes["received_events_url"])
+        if "repos_url" in attributes:  # pragma no branch
+            self._repos_url = self._makeStringAttribute(attributes["repos_url"])
+        if "site_admin" in attributes:  # pragma no branch
+            self._site_admin = self._makeBoolAttribute(attributes["site_admin"])
+        if "starred_url" in attributes:  # pragma no branch
+            self._starred_url = self._makeStringAttribute(attributes["starred_url"])
+        if "subscriptions_url" in attributes:  # pragma no branch
+            self._subscriptions_url = self._makeStringAttribute(attributes["subscriptions_url"])
+        if "total_private_repos" in attributes:  # pragma no branch
+            self._total_private_repos = self._makeIntAttribute(attributes["total_private_repos"])
+        if "type" in attributes:  # pragma no branch
+            self._type = self._makeStringAttribute(attributes["type"])
+        if "updated_at" in attributes:  # pragma no branch
+            self._updated_at = self._makeDatetimeAttribute(attributes["updated_at"])
+        if "url" in attributes:  # pragma no branch
+            self._url = self._makeStringAttribute(attributes["url"])

--- a/github/Authorization.py
+++ b/github/Authorization.py
@@ -1,0 +1,181 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+
+import github.AuthorizationApplication
+
+
+class Authorization(github.GithubObject.CompletableGithubObject):
+    """
+    This class represents Authorizations as returned for example by http://developer.github.com/v3/todo
+    """
+
+    @property
+    def app(self):
+        """
+        :type: :class:`github.AuthorizationApplication.AuthorizationApplication`
+        """
+        self._completeIfNotSet(self._app)
+        return self._app.value
+
+    @property
+    def created_at(self):
+        """
+        :type: datetime.datetime
+        """
+        self._completeIfNotSet(self._created_at)
+        return self._created_at.value
+
+    @property
+    def id(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._id)
+        return self._id.value
+
+    @property
+    def note(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._note)
+        return self._note.value
+
+    @property
+    def note_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._note_url)
+        return self._note_url.value
+
+    @property
+    def scopes(self):
+        """
+        :type: list of string
+        """
+        self._completeIfNotSet(self._scopes)
+        return self._scopes.value
+
+    @property
+    def token(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._token)
+        return self._token.value
+
+    @property
+    def updated_at(self):
+        """
+        :type: datetime.datetime
+        """
+        self._completeIfNotSet(self._updated_at)
+        return self._updated_at.value
+
+    @property
+    def url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._url)
+        return self._url.value
+
+    def delete(self):
+        """
+        :calls: `DELETE /authorizations/:id <http://developer.github.com/v3/oauth>`_
+        :rtype: None
+        """
+        headers, data = self._requester.requestJsonAndCheck(
+            "DELETE",
+            self.url
+        )
+
+    def edit(self, scopes=github.GithubObject.NotSet, add_scopes=github.GithubObject.NotSet, remove_scopes=github.GithubObject.NotSet, note=github.GithubObject.NotSet, note_url=github.GithubObject.NotSet):
+        """
+        :calls: `PATCH /authorizations/:id <http://developer.github.com/v3/oauth>`_
+        :param scopes: list of string
+        :param add_scopes: list of string
+        :param remove_scopes: list of string
+        :param note: string
+        :param note_url: string
+        :rtype: None
+        """
+        assert scopes is github.GithubObject.NotSet or all(isinstance(element, (str, unicode)) for element in scopes), scopes
+        assert add_scopes is github.GithubObject.NotSet or all(isinstance(element, (str, unicode)) for element in add_scopes), add_scopes
+        assert remove_scopes is github.GithubObject.NotSet or all(isinstance(element, (str, unicode)) for element in remove_scopes), remove_scopes
+        assert note is github.GithubObject.NotSet or isinstance(note, (str, unicode)), note
+        assert note_url is github.GithubObject.NotSet or isinstance(note_url, (str, unicode)), note_url
+        post_parameters = dict()
+        if scopes is not github.GithubObject.NotSet:
+            post_parameters["scopes"] = scopes
+        if add_scopes is not github.GithubObject.NotSet:
+            post_parameters["add_scopes"] = add_scopes
+        if remove_scopes is not github.GithubObject.NotSet:
+            post_parameters["remove_scopes"] = remove_scopes
+        if note is not github.GithubObject.NotSet:
+            post_parameters["note"] = note
+        if note_url is not github.GithubObject.NotSet:
+            post_parameters["note_url"] = note_url
+        headers, data = self._requester.requestJsonAndCheck(
+            "PATCH",
+            self.url,
+            input=post_parameters
+        )
+        self._useAttributes(data)
+
+    def _initAttributes(self):
+        self._app = github.GithubObject.NotSet
+        self._created_at = github.GithubObject.NotSet
+        self._id = github.GithubObject.NotSet
+        self._note = github.GithubObject.NotSet
+        self._note_url = github.GithubObject.NotSet
+        self._scopes = github.GithubObject.NotSet
+        self._token = github.GithubObject.NotSet
+        self._updated_at = github.GithubObject.NotSet
+        self._url = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "app" in attributes:  # pragma no branch
+            self._app = self._makeClassAttribute(github.AuthorizationApplication.AuthorizationApplication, attributes["app"])
+        if "created_at" in attributes:  # pragma no branch
+            self._created_at = self._makeDatetimeAttribute(attributes["created_at"])
+        if "id" in attributes:  # pragma no branch
+            self._id = self._makeIntAttribute(attributes["id"])
+        if "note" in attributes:  # pragma no branch
+            self._note = self._makeStringAttribute(attributes["note"])
+        if "note_url" in attributes:  # pragma no branch
+            self._note_url = self._makeStringAttribute(attributes["note_url"])
+        if "scopes" in attributes:  # pragma no branch
+            self._scopes = self._makeListOfStringsAttribute(attributes["scopes"])
+        if "token" in attributes:  # pragma no branch
+            self._token = self._makeStringAttribute(attributes["token"])
+        if "updated_at" in attributes:  # pragma no branch
+            self._updated_at = self._makeDatetimeAttribute(attributes["updated_at"])
+        if "url" in attributes:  # pragma no branch
+            self._url = self._makeStringAttribute(attributes["url"])

--- a/github/AuthorizationApplication.py
+++ b/github/AuthorizationApplication.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+
+
+class AuthorizationApplication(github.GithubObject.CompletableGithubObject):
+    """
+    This class represents AuthorizationApplications as returned for example by http://developer.github.com/v3/todo
+    """
+
+    @property
+    def name(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._name)
+        return self._name.value
+
+    @property
+    def url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._url)
+        return self._url.value
+
+    def _initAttributes(self):
+        self._name = github.GithubObject.NotSet
+        self._url = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "name" in attributes:  # pragma no branch
+            self._name = self._makeStringAttribute(attributes["name"])
+        if "url" in attributes:  # pragma no branch
+            self._url = self._makeStringAttribute(attributes["url"])

--- a/github/Branch.py
+++ b/github/Branch.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2013 martinqt <m.ki2@laposte.net>                                  #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+
+import github.Commit
+
+
+class Branch(github.GithubObject.NonCompletableGithubObject):
+    """
+    This class represents Branchs. The reference can be found here http://developer.github.com/v3/repos/#list-branches
+    """
+
+    @property
+    def commit(self):
+        """
+        :type: :class:`github.Commit.Commit`
+        """
+        return self._commit.value
+
+    @property
+    def name(self):
+        """
+        :type: string
+        """
+        return self._name.value
+
+    def _initAttributes(self):
+        self._commit = github.GithubObject.NotSet
+        self._name = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "commit" in attributes:  # pragma no branch
+            self._commit = self._makeClassAttribute(github.Commit.Commit, attributes["commit"])
+        if "name" in attributes:  # pragma no branch
+            self._name = self._makeStringAttribute(attributes["name"])

--- a/github/Commit.py
+++ b/github/Commit.py
@@ -1,0 +1,242 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2013 martinqt <m.ki2@laposte.net>                                  #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+import github.PaginatedList
+
+import github.GitCommit
+import github.NamedUser
+import github.CommitStatus
+import github.File
+import github.CommitStats
+import github.CommitComment
+
+
+class Commit(github.GithubObject.CompletableGithubObject):
+    """
+    This class represents Commits. The reference can be found here http://developer.github.com/v3/git/commits/
+    """
+
+    @property
+    def author(self):
+        """
+        :type: :class:`github.NamedUser.NamedUser`
+        """
+        self._completeIfNotSet(self._author)
+        return self._author.value
+
+    @property
+    def comments_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._comments_url)
+        return self._comments_url.value
+
+    @property
+    def commit(self):
+        """
+        :type: :class:`github.GitCommit.GitCommit`
+        """
+        self._completeIfNotSet(self._commit)
+        return self._commit.value
+
+    @property
+    def committer(self):
+        """
+        :type: :class:`github.NamedUser.NamedUser`
+        """
+        self._completeIfNotSet(self._committer)
+        return self._committer.value
+
+    @property
+    def files(self):
+        """
+        :type: list of :class:`github.File.File`
+        """
+        self._completeIfNotSet(self._files)
+        return self._files.value
+
+    @property
+    def html_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._html_url)
+        return self._html_url.value
+
+    @property
+    def parents(self):
+        """
+        :type: list of :class:`github.Commit.Commit`
+        """
+        self._completeIfNotSet(self._parents)
+        return self._parents.value
+
+    @property
+    def sha(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._sha)
+        return self._sha.value
+
+    @property
+    def stats(self):
+        """
+        :type: :class:`github.CommitStats.CommitStats`
+        """
+        self._completeIfNotSet(self._stats)
+        return self._stats.value
+
+    @property
+    def url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._url)
+        return self._url.value
+
+    def create_comment(self, body, line=github.GithubObject.NotSet, path=github.GithubObject.NotSet, position=github.GithubObject.NotSet):
+        """
+        :calls: `POST /repos/:owner/:repo/commits/:sha/comments <http://developer.github.com/v3/repos/comments>`_
+        :param body: string
+        :param line: integer
+        :param path: string
+        :param position: integer
+        :rtype: :class:`github.CommitComment.CommitComment`
+        """
+        assert isinstance(body, (str, unicode)), body
+        assert line is github.GithubObject.NotSet or isinstance(line, (int, long)), line
+        assert path is github.GithubObject.NotSet or isinstance(path, (str, unicode)), path
+        assert position is github.GithubObject.NotSet or isinstance(position, (int, long)), position
+        post_parameters = {
+            "body": body,
+        }
+        if line is not github.GithubObject.NotSet:
+            post_parameters["line"] = line
+        if path is not github.GithubObject.NotSet:
+            post_parameters["path"] = path
+        if position is not github.GithubObject.NotSet:
+            post_parameters["position"] = position
+        headers, data = self._requester.requestJsonAndCheck(
+            "POST",
+            self.url + "/comments",
+            input=post_parameters
+        )
+        return github.CommitComment.CommitComment(self._requester, headers, data, completed=True)
+
+    def create_status(self, state, target_url=github.GithubObject.NotSet, description=github.GithubObject.NotSet, context=github.GithubObject.NotSet):
+        """
+        :calls: `POST /repos/:owner/:repo/statuses/:sha <http://developer.github.com/v3/repos/statuses>`_
+        :param state: string
+        :param target_url: string
+        :param description: string
+        :param context: string
+        :rtype: :class:`github.CommitStatus.CommitStatus`
+        """
+        assert isinstance(state, (str, unicode)), state
+        assert target_url is github.GithubObject.NotSet or isinstance(target_url, (str, unicode)), target_url
+        assert description is github.GithubObject.NotSet or isinstance(description, (str, unicode)), description
+        assert context is github.GithubObject.NotSet or isinstance(context, (str, unicode)), context
+        post_parameters = {
+            "state": state,
+        }
+        if target_url is not github.GithubObject.NotSet:
+            post_parameters["target_url"] = target_url
+        if description is not github.GithubObject.NotSet:
+            post_parameters["description"] = description
+        if context is not github.GithubObject.NotSet:
+            post_parameters["context"] = context
+        headers, data = self._requester.requestJsonAndCheck(
+            "POST",
+            self._parentUrl(self._parentUrl(self.url)) + "/statuses/" + self.sha,
+            input=post_parameters
+        )
+        return github.CommitStatus.CommitStatus(self._requester, headers, data, completed=True)
+
+    def get_comments(self):
+        """
+        :calls: `GET /repos/:owner/:repo/commits/:sha/comments <http://developer.github.com/v3/repos/comments>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.CommitComment.CommitComment`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.CommitComment.CommitComment,
+            self._requester,
+            self.url + "/comments",
+            None
+        )
+
+    def get_statuses(self):
+        """
+        :calls: `GET /repos/:owner/:repo/statuses/:ref <http://developer.github.com/v3/repos/statuses>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.CommitStatus.CommitStatus`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.CommitStatus.CommitStatus,
+            self._requester,
+            self._parentUrl(self._parentUrl(self.url)) + "/statuses/" + self.sha,
+            None
+        )
+
+    @property
+    def _identity(self):
+        return self.sha
+
+    def _initAttributes(self):
+        self._author = github.GithubObject.NotSet
+        self._comments_url = github.GithubObject.NotSet
+        self._commit = github.GithubObject.NotSet
+        self._committer = github.GithubObject.NotSet
+        self._files = github.GithubObject.NotSet
+        self._html_url = github.GithubObject.NotSet
+        self._parents = github.GithubObject.NotSet
+        self._sha = github.GithubObject.NotSet
+        self._stats = github.GithubObject.NotSet
+        self._url = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "author" in attributes:  # pragma no branch
+            self._author = self._makeClassAttribute(github.NamedUser.NamedUser, attributes["author"])
+        if "comments_url" in attributes:  # pragma no branch
+            self._comments_url = self._makeStringAttribute(attributes["comments_url"])
+        if "commit" in attributes:  # pragma no branch
+            self._commit = self._makeClassAttribute(github.GitCommit.GitCommit, attributes["commit"])
+        if "committer" in attributes:  # pragma no branch
+            self._committer = self._makeClassAttribute(github.NamedUser.NamedUser, attributes["committer"])
+        if "files" in attributes:  # pragma no branch
+            self._files = self._makeListOfClassesAttribute(github.File.File, attributes["files"])
+        if "html_url" in attributes:  # pragma no branch
+            self._html_url = self._makeStringAttribute(attributes["html_url"])
+        if "parents" in attributes:  # pragma no branch
+            self._parents = self._makeListOfClassesAttribute(Commit, attributes["parents"])
+        if "sha" in attributes:  # pragma no branch
+            self._sha = self._makeStringAttribute(attributes["sha"])
+        if "stats" in attributes:  # pragma no branch
+            self._stats = self._makeClassAttribute(github.CommitStats.CommitStats, attributes["stats"])
+        if "url" in attributes:  # pragma no branch
+            self._url = self._makeStringAttribute(attributes["url"])

--- a/github/CommitComment.py
+++ b/github/CommitComment.py
@@ -1,0 +1,187 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+
+import github.NamedUser
+
+
+class CommitComment(github.GithubObject.CompletableGithubObject):
+    """
+    This class represents CommitComments as returned for example by http://developer.github.com/v3/todo
+    """
+
+    @property
+    def body(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._body)
+        return self._body.value
+
+    @property
+    def commit_id(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._commit_id)
+        return self._commit_id.value
+
+    @property
+    def created_at(self):
+        """
+        :type: datetime.datetime
+        """
+        self._completeIfNotSet(self._created_at)
+        return self._created_at.value
+
+    @property
+    def html_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._html_url)
+        return self._html_url.value
+
+    @property
+    def id(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._id)
+        return self._id.value
+
+    @property
+    def line(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._line)
+        return self._line.value
+
+    @property
+    def path(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._path)
+        return self._path.value
+
+    @property
+    def position(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._position)
+        return self._position.value
+
+    @property
+    def updated_at(self):
+        """
+        :type: datetime.datetime
+        """
+        self._completeIfNotSet(self._updated_at)
+        return self._updated_at.value
+
+    @property
+    def url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._url)
+        return self._url.value
+
+    @property
+    def user(self):
+        """
+        :type: :class:`github.NamedUser.NamedUser`
+        """
+        self._completeIfNotSet(self._user)
+        return self._user.value
+
+    def delete(self):
+        """
+        :calls: `DELETE /repos/:owner/:repo/comments/:id <http://developer.github.com/v3/repos/comments>`_
+        :rtype: None
+        """
+        headers, data = self._requester.requestJsonAndCheck(
+            "DELETE",
+            self.url
+        )
+
+    def edit(self, body):
+        """
+        :calls: `PATCH /repos/:owner/:repo/comments/:id <http://developer.github.com/v3/repos/comments>`_
+        :param body: string
+        :rtype: None
+        """
+        assert isinstance(body, (str, unicode)), body
+        post_parameters = {
+            "body": body,
+        }
+        headers, data = self._requester.requestJsonAndCheck(
+            "PATCH",
+            self.url,
+            input=post_parameters
+        )
+        self._useAttributes(data)
+
+    def _initAttributes(self):
+        self._body = github.GithubObject.NotSet
+        self._commit_id = github.GithubObject.NotSet
+        self._created_at = github.GithubObject.NotSet
+        self._html_url = github.GithubObject.NotSet
+        self._id = github.GithubObject.NotSet
+        self._line = github.GithubObject.NotSet
+        self._path = github.GithubObject.NotSet
+        self._position = github.GithubObject.NotSet
+        self._updated_at = github.GithubObject.NotSet
+        self._url = github.GithubObject.NotSet
+        self._user = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "body" in attributes:  # pragma no branch
+            self._body = self._makeStringAttribute(attributes["body"])
+        if "commit_id" in attributes:  # pragma no branch
+            self._commit_id = self._makeStringAttribute(attributes["commit_id"])
+        if "created_at" in attributes:  # pragma no branch
+            self._created_at = self._makeDatetimeAttribute(attributes["created_at"])
+        if "html_url" in attributes:  # pragma no branch
+            self._html_url = self._makeStringAttribute(attributes["html_url"])
+        if "id" in attributes:  # pragma no branch
+            self._id = self._makeIntAttribute(attributes["id"])
+        if "line" in attributes:  # pragma no branch
+            self._line = self._makeIntAttribute(attributes["line"])
+        if "path" in attributes:  # pragma no branch
+            self._path = self._makeStringAttribute(attributes["path"])
+        if "position" in attributes:  # pragma no branch
+            self._position = self._makeIntAttribute(attributes["position"])
+        if "updated_at" in attributes:  # pragma no branch
+            self._updated_at = self._makeDatetimeAttribute(attributes["updated_at"])
+        if "url" in attributes:  # pragma no branch
+            self._url = self._makeStringAttribute(attributes["url"])
+        if "user" in attributes:  # pragma no branch
+            self._user = self._makeClassAttribute(github.NamedUser.NamedUser, attributes["user"])

--- a/github/CommitStats.py
+++ b/github/CommitStats.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+
+
+class CommitStats(github.GithubObject.NonCompletableGithubObject):
+    """
+    This class represents CommitStatss as returned for example by http://developer.github.com/v3/todo
+    """
+
+    @property
+    def additions(self):
+        """
+        :type: integer
+        """
+        return self._additions.value
+
+    @property
+    def deletions(self):
+        """
+        :type: integer
+        """
+        return self._deletions.value
+
+    @property
+    def total(self):
+        """
+        :type: integer
+        """
+        return self._total.value
+
+    def _initAttributes(self):
+        self._additions = github.GithubObject.NotSet
+        self._deletions = github.GithubObject.NotSet
+        self._total = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "additions" in attributes:  # pragma no branch
+            self._additions = self._makeIntAttribute(attributes["additions"])
+        if "deletions" in attributes:  # pragma no branch
+            self._deletions = self._makeIntAttribute(attributes["deletions"])
+        if "total" in attributes:  # pragma no branch
+            self._total = self._makeIntAttribute(attributes["total"])

--- a/github/CommitStatus.py
+++ b/github/CommitStatus.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+
+import github.NamedUser
+
+
+class CommitStatus(github.GithubObject.NonCompletableGithubObject):
+    """
+    This class represents CommitStatuss as returned for example by https://developer.github.com/v3/repos/statuses/
+    """
+
+    @property
+    def created_at(self):
+        """
+        :type: datetime.datetime
+        """
+        return self._created_at.value
+
+    @property
+    def creator(self):
+        """
+        :type: :class:`github.NamedUser.NamedUser`
+        """
+        return self._creator.value
+
+    @property
+    def description(self):
+        """
+        :type: string
+        """
+        return self._description.value
+
+    @property
+    def id(self):
+        """
+        :type: integer
+        """
+        return self._id.value
+
+    @property
+    def state(self):
+        """
+        :type: string
+        """
+        return self._state.value
+
+    @property
+    def target_url(self):
+        """
+        :type: string
+        """
+        return self._target_url.value
+
+    @property
+    def updated_at(self):
+        """
+        :type: datetime.datetime
+        """
+        return self._updated_at.value
+
+    @property
+    def url(self):
+        """
+        :type: string
+        """
+        return self._url.value
+
+    def _initAttributes(self):
+        self._created_at = github.GithubObject.NotSet
+        self._creator = github.GithubObject.NotSet
+        self._description = github.GithubObject.NotSet
+        self._id = github.GithubObject.NotSet
+        self._state = github.GithubObject.NotSet
+        self._target_url = github.GithubObject.NotSet
+        self._updated_at = github.GithubObject.NotSet
+        self._url = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "created_at" in attributes:  # pragma no branch
+            self._created_at = self._makeDatetimeAttribute(attributes["created_at"])
+        if "creator" in attributes:  # pragma no branch
+            self._creator = self._makeClassAttribute(github.NamedUser.NamedUser, attributes["creator"])
+        if "description" in attributes:  # pragma no branch
+            self._description = self._makeStringAttribute(attributes["description"])
+        if "id" in attributes:  # pragma no branch
+            self._id = self._makeIntAttribute(attributes["id"])
+        if "state" in attributes:  # pragma no branch
+            self._state = self._makeStringAttribute(attributes["state"])
+        if "target_url" in attributes:  # pragma no branch
+            self._target_url = self._makeStringAttribute(attributes["target_url"])
+        if "updated_at" in attributes:  # pragma no branch
+            self._updated_at = self._makeDatetimeAttribute(attributes["updated_at"])
+        if "url" in attributes:  # pragma no branch
+            self._url = self._makeStringAttribute(attributes["url"])

--- a/github/Comparison.py
+++ b/github/Comparison.py
@@ -1,0 +1,183 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+
+import github.Commit
+import github.File
+
+
+class Comparison(github.GithubObject.CompletableGithubObject):
+    """
+    This class represents Comparisons as returned for example by http://developer.github.com/v3/todo
+    """
+
+    @property
+    def ahead_by(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._ahead_by)
+        return self._ahead_by.value
+
+    @property
+    def base_commit(self):
+        """
+        :type: :class:`github.Commit.Commit`
+        """
+        self._completeIfNotSet(self._base_commit)
+        return self._base_commit.value
+
+    @property
+    def behind_by(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._behind_by)
+        return self._behind_by.value
+
+    @property
+    def commits(self):
+        """
+        :type: list of :class:`github.Commit.Commit`
+        """
+        self._completeIfNotSet(self._commits)
+        return self._commits.value
+
+    @property
+    def diff_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._diff_url)
+        return self._diff_url.value
+
+    @property
+    def files(self):
+        """
+        :type: list of :class:`github.File.File`
+        """
+        self._completeIfNotSet(self._files)
+        return self._files.value
+
+    @property
+    def html_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._html_url)
+        return self._html_url.value
+
+    @property
+    def merge_base_commit(self):
+        """
+        :type: :class:`github.Commit.Commit`
+        """
+        self._completeIfNotSet(self._merge_base_commit)
+        return self._merge_base_commit.value
+
+    @property
+    def patch_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._patch_url)
+        return self._patch_url.value
+
+    @property
+    def permalink_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._permalink_url)
+        return self._permalink_url.value
+
+    @property
+    def status(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._status)
+        return self._status.value
+
+    @property
+    def total_commits(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._total_commits)
+        return self._total_commits.value
+
+    @property
+    def url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._url)
+        return self._url.value
+
+    def _initAttributes(self):
+        self._ahead_by = github.GithubObject.NotSet
+        self._base_commit = github.GithubObject.NotSet
+        self._behind_by = github.GithubObject.NotSet
+        self._commits = github.GithubObject.NotSet
+        self._diff_url = github.GithubObject.NotSet
+        self._files = github.GithubObject.NotSet
+        self._html_url = github.GithubObject.NotSet
+        self._merge_base_commit = github.GithubObject.NotSet
+        self._patch_url = github.GithubObject.NotSet
+        self._permalink_url = github.GithubObject.NotSet
+        self._status = github.GithubObject.NotSet
+        self._total_commits = github.GithubObject.NotSet
+        self._url = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "ahead_by" in attributes:  # pragma no branch
+            self._ahead_by = self._makeIntAttribute(attributes["ahead_by"])
+        if "base_commit" in attributes:  # pragma no branch
+            self._base_commit = self._makeClassAttribute(github.Commit.Commit, attributes["base_commit"])
+        if "behind_by" in attributes:  # pragma no branch
+            self._behind_by = self._makeIntAttribute(attributes["behind_by"])
+        if "commits" in attributes:  # pragma no branch
+            self._commits = self._makeListOfClassesAttribute(github.Commit.Commit, attributes["commits"])
+        if "diff_url" in attributes:  # pragma no branch
+            self._diff_url = self._makeStringAttribute(attributes["diff_url"])
+        if "files" in attributes:  # pragma no branch
+            self._files = self._makeListOfClassesAttribute(github.File.File, attributes["files"])
+        if "html_url" in attributes:  # pragma no branch
+            self._html_url = self._makeStringAttribute(attributes["html_url"])
+        if "merge_base_commit" in attributes:  # pragma no branch
+            self._merge_base_commit = self._makeClassAttribute(github.Commit.Commit, attributes["merge_base_commit"])
+        if "patch_url" in attributes:  # pragma no branch
+            self._patch_url = self._makeStringAttribute(attributes["patch_url"])
+        if "permalink_url" in attributes:  # pragma no branch
+            self._permalink_url = self._makeStringAttribute(attributes["permalink_url"])
+        if "status" in attributes:  # pragma no branch
+            self._status = self._makeStringAttribute(attributes["status"])
+        if "total_commits" in attributes:  # pragma no branch
+            self._total_commits = self._makeIntAttribute(attributes["total_commits"])
+        if "url" in attributes:  # pragma no branch
+            self._url = self._makeStringAttribute(attributes["url"])

--- a/github/Consts.py
+++ b/github/Consts.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+# #193: Line endings should be linux style
+
+# TODO: As of Thu Aug 21 22:40:13 (BJT) Chinese Standard Time 2013
+# lots of consts in this project are explict
+# should realy round them up and reference them by consts
+# EDIT: well, maybe :-)
+
+# ##############################################################################
+# Request Header                                                               #
+# (Case sensitive)                                                             #
+# ##############################################################################
+REQ_IF_NONE_MATCH = "If-None-Match"
+REQ_IF_MODIFIED_SINCE = "If-Modified-Since"
+
+# ##############################################################################
+# Response Header                                                              #
+# (Lower Case)                                                                 #
+# ##############################################################################
+RES_ETAG = "etag"
+RES_LAST_MODIFED = "last-modified"

--- a/github/ContentFile.py
+++ b/github/ContentFile.py
@@ -1,0 +1,176 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import base64
+import sys
+
+import github.GithubObject
+import github.Repository
+
+
+atLeastPython3 = sys.hexversion >= 0x03000000
+
+
+class ContentFile(github.GithubObject.CompletableGithubObject):
+    """
+    This class represents ContentFiles as returned for example by http://developer.github.com/v3/todo
+    """
+
+    @property
+    def content(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._content)
+        return self._content.value
+
+    @property
+    def decoded_content(self):
+        assert self.encoding == "base64", "unsupported encoding: %s" % self.encoding
+        if atLeastPython3:
+            content = bytearray(self.content, "utf-8")  # pragma no cover (covered by tests with Python 3.2)
+        else:
+            content = self.content
+        return base64.b64decode(content)
+
+    @property
+    def encoding(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._encoding)
+        return self._encoding.value
+
+    @property
+    def git_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._git_url)
+        return self._git_url.value
+
+    @property
+    def html_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._html_url)
+        return self._html_url.value
+
+    @property
+    def name(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._name)
+        return self._name.value
+
+    @property
+    def path(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._path)
+        return self._path.value
+
+    @property
+    def repository(self):
+        """
+        :type: :class:`github.Repository.Repository`
+        """
+        if self._repository is github.GithubObject.NotSet:
+            # The repository was not set automatically, so it must be looked up by url.
+            repo_url = "/".join(self.url.split("/")[:6])  # pragma no cover (Should be covered)
+            self._repository = github.GithubObject._ValuedAttribute(github.Repository.Repository(self._requester, self._headers, {'url': repo_url}, completed=False))  # pragma no cover (Should be covered)
+        return self._repository.value
+
+    @property
+    def sha(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._sha)
+        return self._sha.value
+
+    @property
+    def size(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._size)
+        return self._size.value
+
+    @property
+    def type(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._type)
+        return self._type.value
+
+    @property
+    def url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._url)
+        return self._url.value
+
+    def _initAttributes(self):
+        self._content = github.GithubObject.NotSet
+        self._encoding = github.GithubObject.NotSet
+        self._git_url = github.GithubObject.NotSet
+        self._html_url = github.GithubObject.NotSet
+        self._name = github.GithubObject.NotSet
+        self._path = github.GithubObject.NotSet
+        self._repository = github.GithubObject.NotSet
+        self._sha = github.GithubObject.NotSet
+        self._size = github.GithubObject.NotSet
+        self._type = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "content" in attributes:  # pragma no branch
+            self._content = self._makeStringAttribute(attributes["content"])
+        if "encoding" in attributes:  # pragma no branch
+            self._encoding = self._makeStringAttribute(attributes["encoding"])
+        if "git_url" in attributes:  # pragma no branch
+            self._git_url = self._makeStringAttribute(attributes["git_url"])
+        if "html_url" in attributes:  # pragma no branch
+            self._html_url = self._makeStringAttribute(attributes["html_url"])
+        if "name" in attributes:  # pragma no branch
+            self._name = self._makeStringAttribute(attributes["name"])
+        if "path" in attributes:  # pragma no branch
+            self._path = self._makeStringAttribute(attributes["path"])
+        if "repository" in attributes:  # pragma no branch
+            self._repository = self._makeClassAttribute(github.Repository.Repository, attributes["repository"])
+        if "sha" in attributes:  # pragma no branch
+            self._sha = self._makeStringAttribute(attributes["sha"])
+        if "size" in attributes:  # pragma no branch
+            self._size = self._makeIntAttribute(attributes["size"])
+        if "type" in attributes:  # pragma no branch
+            self._type = self._makeStringAttribute(attributes["type"])
+        if "url" in attributes:  # pragma no branch
+            self._url = self._makeStringAttribute(attributes["url"])

--- a/github/Download.py
+++ b/github/Download.py
@@ -1,0 +1,267 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+
+
+class Download(github.GithubObject.CompletableGithubObject):
+    """
+    This class represents Downloads as returned for example by http://developer.github.com/v3/todo
+    """
+
+    @property
+    def accesskeyid(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._accesskeyid)
+        return self._accesskeyid.value
+
+    @property
+    def acl(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._acl)
+        return self._acl.value
+
+    @property
+    def bucket(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._bucket)
+        return self._bucket.value
+
+    @property
+    def content_type(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._content_type)
+        return self._content_type.value
+
+    @property
+    def created_at(self):
+        """
+        :type: datetime.datetime
+        """
+        self._completeIfNotSet(self._created_at)
+        return self._created_at.value
+
+    @property
+    def description(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._description)
+        return self._description.value
+
+    @property
+    def download_count(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._download_count)
+        return self._download_count.value
+
+    @property
+    def expirationdate(self):
+        """
+        :type: datetime.datetime
+        """
+        self._completeIfNotSet(self._expirationdate)
+        return self._expirationdate.value
+
+    @property
+    def html_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._html_url)
+        return self._html_url.value
+
+    @property
+    def id(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._id)
+        return self._id.value
+
+    @property
+    def mime_type(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._mime_type)
+        return self._mime_type.value
+
+    @property
+    def name(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._name)
+        return self._name.value
+
+    @property
+    def path(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._path)
+        return self._path.value
+
+    @property
+    def policy(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._policy)
+        return self._policy.value
+
+    @property
+    def prefix(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._prefix)
+        return self._prefix.value
+
+    @property
+    def redirect(self):
+        """
+        :type: bool
+        """
+        self._completeIfNotSet(self._redirect)
+        return self._redirect.value
+
+    @property
+    def s3_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._s3_url)
+        return self._s3_url.value
+
+    @property
+    def signature(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._signature)
+        return self._signature.value
+
+    @property
+    def size(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._size)
+        return self._size.value
+
+    @property
+    def url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._url)
+        return self._url.value
+
+    def delete(self):
+        """
+        :calls: `DELETE /repos/:owner/:repo/downloads/:id <http://developer.github.com/v3/repos/downloads>`_
+        :rtype: None
+        """
+        headers, data = self._requester.requestJsonAndCheck(
+            "DELETE",
+            self.url
+        )
+
+    def _initAttributes(self):
+        self._accesskeyid = github.GithubObject.NotSet
+        self._acl = github.GithubObject.NotSet
+        self._bucket = github.GithubObject.NotSet
+        self._content_type = github.GithubObject.NotSet
+        self._created_at = github.GithubObject.NotSet
+        self._description = github.GithubObject.NotSet
+        self._download_count = github.GithubObject.NotSet
+        self._expirationdate = github.GithubObject.NotSet
+        self._html_url = github.GithubObject.NotSet
+        self._id = github.GithubObject.NotSet
+        self._mime_type = github.GithubObject.NotSet
+        self._name = github.GithubObject.NotSet
+        self._path = github.GithubObject.NotSet
+        self._policy = github.GithubObject.NotSet
+        self._prefix = github.GithubObject.NotSet
+        self._redirect = github.GithubObject.NotSet
+        self._s3_url = github.GithubObject.NotSet
+        self._signature = github.GithubObject.NotSet
+        self._size = github.GithubObject.NotSet
+        self._url = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "accesskeyid" in attributes:  # pragma no branch
+            self._accesskeyid = self._makeStringAttribute(attributes["accesskeyid"])  # pragma no cover (was covered only by create_download, which has been removed)
+        if "acl" in attributes:  # pragma no branch
+            self._acl = self._makeStringAttribute(attributes["acl"])  # pragma no cover (was covered only by create_download, which has been removed)
+        if "bucket" in attributes:  # pragma no branch
+            self._bucket = self._makeStringAttribute(attributes["bucket"])  # pragma no cover (was covered only by create_download, which has been removed)
+        if "content_type" in attributes:  # pragma no branch
+            self._content_type = self._makeStringAttribute(attributes["content_type"])
+        if "created_at" in attributes:  # pragma no branch
+            self._created_at = self._makeDatetimeAttribute(attributes["created_at"])
+        if "description" in attributes:  # pragma no branch
+            self._description = self._makeStringAttribute(attributes["description"])
+        if "download_count" in attributes:  # pragma no branch
+            self._download_count = self._makeIntAttribute(attributes["download_count"])
+        if "expirationdate" in attributes:  # pragma no branch
+            self._expirationdate = self._makeDatetimeAttribute(attributes["expirationdate"])  # pragma no cover (was covered only by create_download, which has been removed)
+        if "html_url" in attributes:  # pragma no branch
+            self._html_url = self._makeStringAttribute(attributes["html_url"])
+        if "id" in attributes:  # pragma no branch
+            self._id = self._makeIntAttribute(attributes["id"])
+        if "mime_type" in attributes:  # pragma no branch
+            self._mime_type = self._makeStringAttribute(attributes["mime_type"])  # pragma no cover (was covered only by create_download, which has been removed)
+        if "name" in attributes:  # pragma no branch
+            self._name = self._makeStringAttribute(attributes["name"])
+        if "path" in attributes:  # pragma no branch
+            self._path = self._makeStringAttribute(attributes["path"])  # pragma no cover (was covered only by create_download, which has been removed)
+        if "policy" in attributes:  # pragma no branch
+            self._policy = self._makeStringAttribute(attributes["policy"])  # pragma no cover (was covered only by create_download, which has been removed)
+        if "prefix" in attributes:  # pragma no branch
+            self._prefix = self._makeStringAttribute(attributes["prefix"])  # pragma no cover (was covered only by create_download, which has been removed)
+        if "redirect" in attributes:  # pragma no branch
+            self._redirect = self._makeBoolAttribute(attributes["redirect"])  # pragma no cover (was covered only by create_download, which has been removed)
+        if "s3_url" in attributes:  # pragma no branch
+            self._s3_url = self._makeStringAttribute(attributes["s3_url"])  # pragma no cover (was covered only by create_download, which has been removed)
+        if "signature" in attributes:  # pragma no branch
+            self._signature = self._makeStringAttribute(attributes["signature"])  # pragma no cover (was covered only by create_download, which has been removed)
+        if "size" in attributes:  # pragma no branch
+            self._size = self._makeIntAttribute(attributes["size"])
+        if "url" in attributes:  # pragma no branch
+            self._url = self._makeStringAttribute(attributes["url"])

--- a/github/Event.py
+++ b/github/Event.py
@@ -1,0 +1,122 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2013 martinqt <m.ki2@laposte.net>                                  #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+
+import github.Organization
+import github.Repository
+import github.NamedUser
+
+
+class Event(github.GithubObject.NonCompletableGithubObject):
+    """
+    This class represents Events. The reference can be found here http://developer.github.com/v3/activity/events/
+    """
+
+    @property
+    def actor(self):
+        """
+        :type: :class:`github.NamedUser.NamedUser`
+        """
+        return self._actor.value
+
+    @property
+    def created_at(self):
+        """
+        :type: datetime.datetime
+        """
+        return self._created_at.value
+
+    @property
+    def id(self):
+        """
+        :type: string
+        """
+        return self._id.value
+
+    @property
+    def org(self):
+        """
+        :type: :class:`github.Organization.Organization`
+        """
+        return self._org.value
+
+    @property
+    def payload(self):
+        """
+        :type: dict
+        """
+        return self._payload.value
+
+    @property
+    def public(self):
+        """
+        :type: bool
+        """
+        return self._public.value
+
+    @property
+    def repo(self):
+        """
+        :type: :class:`github.Repository.Repository`
+        """
+        return self._repo.value
+
+    @property
+    def type(self):
+        """
+        :type: string
+        """
+        return self._type.value
+
+    def _initAttributes(self):
+        self._actor = github.GithubObject.NotSet
+        self._created_at = github.GithubObject.NotSet
+        self._id = github.GithubObject.NotSet
+        self._org = github.GithubObject.NotSet
+        self._payload = github.GithubObject.NotSet
+        self._public = github.GithubObject.NotSet
+        self._repo = github.GithubObject.NotSet
+        self._type = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "actor" in attributes:  # pragma no branch
+            self._actor = self._makeClassAttribute(github.NamedUser.NamedUser, attributes["actor"])
+        if "created_at" in attributes:  # pragma no branch
+            self._created_at = self._makeDatetimeAttribute(attributes["created_at"])
+        if "id" in attributes:  # pragma no branch
+            self._id = self._makeStringAttribute(attributes["id"])
+        if "org" in attributes:  # pragma no branch
+            self._org = self._makeClassAttribute(github.Organization.Organization, attributes["org"])
+        if "payload" in attributes:  # pragma no branch
+            self._payload = self._makeDictAttribute(attributes["payload"])
+        if "public" in attributes:  # pragma no branch
+            self._public = self._makeBoolAttribute(attributes["public"])
+        if "repo" in attributes:  # pragma no branch
+            self._repo = self._makeClassAttribute(github.Repository.Repository, attributes["repo"])
+        if "type" in attributes:  # pragma no branch
+            self._type = self._makeStringAttribute(attributes["type"])

--- a/github/File.py
+++ b/github/File.py
@@ -1,0 +1,137 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+
+
+class File(github.GithubObject.NonCompletableGithubObject):
+    """
+    This class represents Files as returned for example by http://developer.github.com/v3/todo
+    """
+
+    @property
+    def additions(self):
+        """
+        :type: integer
+        """
+        return self._additions.value
+
+    @property
+    def blob_url(self):
+        """
+        :type: string
+        """
+        return self._blob_url.value
+
+    @property
+    def changes(self):
+        """
+        :type: integer
+        """
+        return self._changes.value
+
+    @property
+    def contents_url(self):
+        """
+        :type: string
+        """
+        return self._contents_url.value
+
+    @property
+    def deletions(self):
+        """
+        :type: integer
+        """
+        return self._deletions.value
+
+    @property
+    def filename(self):
+        """
+        :type: string
+        """
+        return self._filename.value
+
+    @property
+    def patch(self):
+        """
+        :type: string
+        """
+        return self._patch.value
+
+    @property
+    def raw_url(self):
+        """
+        :type: string
+        """
+        return self._raw_url.value
+
+    @property
+    def sha(self):
+        """
+        :type: string
+        """
+        return self._sha.value
+
+    @property
+    def status(self):
+        """
+        :type: string
+        """
+        return self._status.value
+
+    def _initAttributes(self):
+        self._additions = github.GithubObject.NotSet
+        self._blob_url = github.GithubObject.NotSet
+        self._changes = github.GithubObject.NotSet
+        self._contents_url = github.GithubObject.NotSet
+        self._deletions = github.GithubObject.NotSet
+        self._filename = github.GithubObject.NotSet
+        self._patch = github.GithubObject.NotSet
+        self._raw_url = github.GithubObject.NotSet
+        self._sha = github.GithubObject.NotSet
+        self._status = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "additions" in attributes:  # pragma no branch
+            self._additions = self._makeIntAttribute(attributes["additions"])
+        if "blob_url" in attributes:  # pragma no branch
+            self._blob_url = self._makeStringAttribute(attributes["blob_url"])
+        if "changes" in attributes:  # pragma no branch
+            self._changes = self._makeIntAttribute(attributes["changes"])
+        if "contents_url" in attributes:  # pragma no branch
+            self._contents_url = self._makeStringAttribute(attributes["contents_url"])
+        if "deletions" in attributes:  # pragma no branch
+            self._deletions = self._makeIntAttribute(attributes["deletions"])
+        if "filename" in attributes:  # pragma no branch
+            self._filename = self._makeStringAttribute(attributes["filename"])
+        if "patch" in attributes:  # pragma no branch
+            self._patch = self._makeStringAttribute(attributes["patch"])
+        if "raw_url" in attributes:  # pragma no branch
+            self._raw_url = self._makeStringAttribute(attributes["raw_url"])
+        if "sha" in attributes:  # pragma no branch
+            self._sha = self._makeStringAttribute(attributes["sha"])
+        if "status" in attributes:  # pragma no branch
+            self._status = self._makeStringAttribute(attributes["status"])

--- a/github/Gist.py
+++ b/github/Gist.py
@@ -1,0 +1,368 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Steve English <steve.english@navetas.com>                     #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+import github.PaginatedList
+
+import github.GistComment
+import github.NamedUser
+import github.GistFile
+import github.GistHistoryState
+
+
+class Gist(github.GithubObject.CompletableGithubObject):
+    """
+    This class represents Gists as returned for example by http://developer.github.com/v3/todo
+    """
+
+    @property
+    def comments(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._comments)
+        return self._comments.value
+
+    @property
+    def comments_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._comments_url)
+        return self._comments_url.value
+
+    @property
+    def commits_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._commits_url)
+        return self._commits_url.value
+
+    @property
+    def created_at(self):
+        """
+        :type: datetime.datetime
+        """
+        self._completeIfNotSet(self._created_at)
+        return self._created_at.value
+
+    @property
+    def description(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._description)
+        return self._description.value
+
+    @property
+    def files(self):
+        """
+        :type: dict of string to :class:`github.GistFile.GistFile`
+        """
+        self._completeIfNotSet(self._files)
+        return self._files.value
+
+    @property
+    def fork_of(self):
+        """
+        :type: :class:`github.Gist.Gist`
+        """
+        self._completeIfNotSet(self._fork_of)
+        return self._fork_of.value
+
+    @property
+    def forks(self):
+        """
+        :type: list of :class:`github.Gist.Gist`
+        """
+        self._completeIfNotSet(self._forks)
+        return self._forks.value
+
+    @property
+    def forks_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._forks_url)
+        return self._forks_url.value
+
+    @property
+    def git_pull_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._git_pull_url)
+        return self._git_pull_url.value
+
+    @property
+    def git_push_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._git_push_url)
+        return self._git_push_url.value
+
+    @property
+    def history(self):
+        """
+        :type: list of :class:`github.GistHistoryState.GistHistoryState`
+        """
+        self._completeIfNotSet(self._history)
+        return self._history.value
+
+    @property
+    def html_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._html_url)
+        return self._html_url.value
+
+    @property
+    def id(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._id)
+        return self._id.value
+
+    @property
+    def owner(self):
+        """
+        :type: :class:`github.NamedUser.NamedUser`
+        """
+        self._completeIfNotSet(self._owner)
+        return self._owner.value
+
+    @property
+    def public(self):
+        """
+        :type: bool
+        """
+        self._completeIfNotSet(self._public)
+        return self._public.value
+
+    @property
+    def updated_at(self):
+        """
+        :type: datetime.datetime
+        """
+        self._completeIfNotSet(self._updated_at)
+        return self._updated_at.value
+
+    @property
+    def url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._url)
+        return self._url.value
+
+    @property
+    def user(self):
+        """
+        :type: :class:`github.NamedUser.NamedUser`
+        """
+        self._completeIfNotSet(self._user)
+        return self._user.value
+
+    def create_comment(self, body):
+        """
+        :calls: `POST /gists/:gist_id/comments <http://developer.github.com/v3/gists/comments>`_
+        :param body: string
+        :rtype: :class:`github.GistComment.GistComment`
+        """
+        assert isinstance(body, (str, unicode)), body
+        post_parameters = {
+            "body": body,
+        }
+        headers, data = self._requester.requestJsonAndCheck(
+            "POST",
+            self.url + "/comments",
+            input=post_parameters
+        )
+        return github.GistComment.GistComment(self._requester, headers, data, completed=True)
+
+    def create_fork(self):
+        """
+        :calls: `POST /gists/:id/forks <http://developer.github.com/v3/gists>`_
+        :rtype: :class:`github.Gist.Gist`
+        """
+        headers, data = self._requester.requestJsonAndCheck(
+            "POST",
+            self.url + "/forks"
+        )
+        return Gist(self._requester, headers, data, completed=True)
+
+    def delete(self):
+        """
+        :calls: `DELETE /gists/:id <http://developer.github.com/v3/gists>`_
+        :rtype: None
+        """
+        headers, data = self._requester.requestJsonAndCheck(
+            "DELETE",
+            self.url
+        )
+
+    def edit(self, description=github.GithubObject.NotSet, files=github.GithubObject.NotSet):
+        """
+        :calls: `PATCH /gists/:id <http://developer.github.com/v3/gists>`_
+        :param description: string
+        :param files: dict of string to :class:`github.InputFileContent.InputFileContent`
+        :rtype: None
+        """
+        assert description is github.GithubObject.NotSet or isinstance(description, (str, unicode)), description
+        assert files is github.GithubObject.NotSet or all(element is None or isinstance(element, github.InputFileContent) for element in files.itervalues()), files
+        post_parameters = dict()
+        if description is not github.GithubObject.NotSet:
+            post_parameters["description"] = description
+        if files is not github.GithubObject.NotSet:
+            post_parameters["files"] = dict((key, None if value is None else value._identity) for key, value in files.iteritems())
+        headers, data = self._requester.requestJsonAndCheck(
+            "PATCH",
+            self.url,
+            input=post_parameters
+        )
+        self._useAttributes(data)
+
+    def get_comment(self, id):
+        """
+        :calls: `GET /gists/:gist_id/comments/:id <http://developer.github.com/v3/gists/comments>`_
+        :param id: integer
+        :rtype: :class:`github.GistComment.GistComment`
+        """
+        assert isinstance(id, (int, long)), id
+        headers, data = self._requester.requestJsonAndCheck(
+            "GET",
+            self.url + "/comments/" + str(id)
+        )
+        return github.GistComment.GistComment(self._requester, headers, data, completed=True)
+
+    def get_comments(self):
+        """
+        :calls: `GET /gists/:gist_id/comments <http://developer.github.com/v3/gists/comments>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.GistComment.GistComment`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.GistComment.GistComment,
+            self._requester,
+            self.url + "/comments",
+            None
+        )
+
+    def is_starred(self):
+        """
+        :calls: `GET /gists/:id/star <http://developer.github.com/v3/gists>`_
+        :rtype: bool
+        """
+        status, headers, data = self._requester.requestJson(
+            "GET",
+            self.url + "/star"
+        )
+        return status == 204
+
+    def reset_starred(self):
+        """
+        :calls: `DELETE /gists/:id/star <http://developer.github.com/v3/gists>`_
+        :rtype: None
+        """
+        headers, data = self._requester.requestJsonAndCheck(
+            "DELETE",
+            self.url + "/star"
+        )
+
+    def set_starred(self):
+        """
+        :calls: `PUT /gists/:id/star <http://developer.github.com/v3/gists>`_
+        :rtype: None
+        """
+        headers, data = self._requester.requestJsonAndCheck(
+            "PUT",
+            self.url + "/star"
+        )
+
+    def _initAttributes(self):
+        self._comments = github.GithubObject.NotSet
+        self._comments_url = github.GithubObject.NotSet
+        self._commits_url = github.GithubObject.NotSet
+        self._created_at = github.GithubObject.NotSet
+        self._description = github.GithubObject.NotSet
+        self._files = github.GithubObject.NotSet
+        self._fork_of = github.GithubObject.NotSet
+        self._forks = github.GithubObject.NotSet
+        self._forks_url = github.GithubObject.NotSet
+        self._git_pull_url = github.GithubObject.NotSet
+        self._git_push_url = github.GithubObject.NotSet
+        self._history = github.GithubObject.NotSet
+        self._html_url = github.GithubObject.NotSet
+        self._id = github.GithubObject.NotSet
+        self._owner = github.GithubObject.NotSet
+        self._public = github.GithubObject.NotSet
+        self._updated_at = github.GithubObject.NotSet
+        self._url = github.GithubObject.NotSet
+        self._user = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "comments" in attributes:  # pragma no branch
+            self._comments = self._makeIntAttribute(attributes["comments"])
+        if "comments_url" in attributes:  # pragma no branch
+            self._comments_url = self._makeStringAttribute(attributes["comments_url"])
+        if "commits_url" in attributes:  # pragma no branch
+            self._commits_url = self._makeStringAttribute(attributes["commits_url"])
+        if "created_at" in attributes:  # pragma no branch
+            self._created_at = self._makeDatetimeAttribute(attributes["created_at"])
+        if "description" in attributes:  # pragma no branch
+            self._description = self._makeStringAttribute(attributes["description"])
+        if "files" in attributes:  # pragma no branch
+            self._files = self._makeDictOfStringsToClassesAttribute(github.GistFile.GistFile, attributes["files"])
+        if "fork_of" in attributes:  # pragma no branch
+            self._fork_of = self._makeClassAttribute(Gist, attributes["fork_of"])
+        if "forks" in attributes:  # pragma no branch
+            self._forks = self._makeListOfClassesAttribute(Gist, attributes["forks"])
+        if "forks_url" in attributes:  # pragma no branch
+            self._forks_url = self._makeStringAttribute(attributes["forks_url"])
+        if "git_pull_url" in attributes:  # pragma no branch
+            self._git_pull_url = self._makeStringAttribute(attributes["git_pull_url"])
+        if "git_push_url" in attributes:  # pragma no branch
+            self._git_push_url = self._makeStringAttribute(attributes["git_push_url"])
+        if "history" in attributes:  # pragma no branch
+            self._history = self._makeListOfClassesAttribute(github.GistHistoryState.GistHistoryState, attributes["history"])
+        if "html_url" in attributes:  # pragma no branch
+            self._html_url = self._makeStringAttribute(attributes["html_url"])
+        if "id" in attributes:  # pragma no branch
+            self._id = self._makeStringAttribute(attributes["id"])
+        if "owner" in attributes:  # pragma no branch
+            self._owner = self._makeClassAttribute(github.NamedUser.NamedUser, attributes["owner"])
+        if "public" in attributes:  # pragma no branch
+            self._public = self._makeBoolAttribute(attributes["public"])
+        if "updated_at" in attributes:  # pragma no branch
+            self._updated_at = self._makeDatetimeAttribute(attributes["updated_at"])
+        if "url" in attributes:  # pragma no branch
+            self._url = self._makeStringAttribute(attributes["url"])
+        if "user" in attributes:  # pragma no branch
+            self._user = self._makeClassAttribute(github.NamedUser.NamedUser, attributes["user"])

--- a/github/GistComment.py
+++ b/github/GistComment.py
@@ -1,0 +1,132 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+
+import github.NamedUser
+
+
+class GistComment(github.GithubObject.CompletableGithubObject):
+    """
+    This class represents GistComments as returned for example by http://developer.github.com/v3/todo
+    """
+
+    @property
+    def body(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._body)
+        return self._body.value
+
+    @property
+    def created_at(self):
+        """
+        :type: datetime.datetime
+        """
+        self._completeIfNotSet(self._created_at)
+        return self._created_at.value
+
+    @property
+    def id(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._id)
+        return self._id.value
+
+    @property
+    def updated_at(self):
+        """
+        :type: datetime.datetime
+        """
+        self._completeIfNotSet(self._updated_at)
+        return self._updated_at.value
+
+    @property
+    def url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._url)
+        return self._url.value
+
+    @property
+    def user(self):
+        """
+        :type: :class:`github.NamedUser.NamedUser`
+        """
+        self._completeIfNotSet(self._user)
+        return self._user.value
+
+    def delete(self):
+        """
+        :calls: `DELETE /gists/:gist_id/comments/:id <http://developer.github.com/v3/gists/comments>`_
+        :rtype: None
+        """
+        headers, data = self._requester.requestJsonAndCheck(
+            "DELETE",
+            self.url
+        )
+
+    def edit(self, body):
+        """
+        :calls: `PATCH /gists/:gist_id/comments/:id <http://developer.github.com/v3/gists/comments>`_
+        :param body: string
+        :rtype: None
+        """
+        assert isinstance(body, (str, unicode)), body
+        post_parameters = {
+            "body": body,
+        }
+        headers, data = self._requester.requestJsonAndCheck(
+            "PATCH",
+            self.url,
+            input=post_parameters
+        )
+        self._useAttributes(data)
+
+    def _initAttributes(self):
+        self._body = github.GithubObject.NotSet
+        self._created_at = github.GithubObject.NotSet
+        self._id = github.GithubObject.NotSet
+        self._updated_at = github.GithubObject.NotSet
+        self._url = github.GithubObject.NotSet
+        self._user = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "body" in attributes:  # pragma no branch
+            self._body = self._makeStringAttribute(attributes["body"])
+        if "created_at" in attributes:  # pragma no branch
+            self._created_at = self._makeDatetimeAttribute(attributes["created_at"])
+        if "id" in attributes:  # pragma no branch
+            self._id = self._makeIntAttribute(attributes["id"])
+        if "updated_at" in attributes:  # pragma no branch
+            self._updated_at = self._makeDatetimeAttribute(attributes["updated_at"])
+        if "url" in attributes:  # pragma no branch
+            self._url = self._makeStringAttribute(attributes["url"])
+        if "user" in attributes:  # pragma no branch
+            self._user = self._makeClassAttribute(github.NamedUser.NamedUser, attributes["user"])

--- a/github/GistFile.py
+++ b/github/GistFile.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+
+
+class GistFile(github.GithubObject.NonCompletableGithubObject):
+    """
+    This class represents GistFiles as returned for example by http://developer.github.com/v3/todo
+    """
+
+    @property
+    def content(self):
+        """
+        :type: string
+        """
+        return self._content.value
+
+    @property
+    def filename(self):
+        """
+        :type: string
+        """
+        return self._filename.value
+
+    @property
+    def language(self):
+        """
+        :type: string
+        """
+        return self._language.value
+
+    @property
+    def raw_url(self):
+        """
+        :type: string
+        """
+        return self._raw_url.value
+
+    @property
+    def size(self):
+        """
+        :type: integer
+        """
+        return self._size.value
+
+    @property
+    def type(self):
+        """
+        :type: string
+        """
+        return self._type.value
+
+    def _initAttributes(self):
+        self._content = github.GithubObject.NotSet
+        self._filename = github.GithubObject.NotSet
+        self._language = github.GithubObject.NotSet
+        self._raw_url = github.GithubObject.NotSet
+        self._size = github.GithubObject.NotSet
+        self._type = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "content" in attributes:  # pragma no branch
+            self._content = self._makeStringAttribute(attributes["content"])
+        if "filename" in attributes:  # pragma no branch
+            self._filename = self._makeStringAttribute(attributes["filename"])
+        if "language" in attributes:  # pragma no branch
+            self._language = self._makeStringAttribute(attributes["language"])
+        if "raw_url" in attributes:  # pragma no branch
+            self._raw_url = self._makeStringAttribute(attributes["raw_url"])
+        if "size" in attributes:  # pragma no branch
+            self._size = self._makeIntAttribute(attributes["size"])
+        if "type" in attributes:  # pragma no branch
+            self._type = self._makeStringAttribute(attributes["type"])

--- a/github/GistHistoryState.py
+++ b/github/GistHistoryState.py
@@ -1,0 +1,272 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+
+import github.NamedUser
+import github.CommitStats
+import github.Gist
+
+
+class GistHistoryState(github.GithubObject.CompletableGithubObject):
+    """
+    This class represents GistHistoryStates as returned for example by http://developer.github.com/v3/todo
+    """
+
+    @property
+    def change_status(self):
+        """
+        :type: :class:`github.CommitStats.CommitStats`
+        """
+        self._completeIfNotSet(self._change_status)
+        return self._change_status.value
+
+    @property
+    def comments(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._comments)
+        return self._comments.value
+
+    @property
+    def comments_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._comments_url)
+        return self._comments_url.value
+
+    @property
+    def commits_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._commits_url)
+        return self._commits_url.value
+
+    @property
+    def committed_at(self):
+        """
+        :type: datetime.datetime
+        """
+        self._completeIfNotSet(self._committed_at)
+        return self._committed_at.value
+
+    @property
+    def created_at(self):
+        """
+        :type: datetime.datetime
+        """
+        self._completeIfNotSet(self._created_at)
+        return self._created_at.value
+
+    @property
+    def description(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._description)
+        return self._description.value
+
+    @property
+    def files(self):
+        """
+        :type: dict of string to :class:`github.GistFile.GistFile`
+        """
+        self._completeIfNotSet(self._files)
+        return self._files.value
+
+    @property
+    def forks(self):
+        """
+        :type: list of :class:`github.Gist.Gist`
+        """
+        self._completeIfNotSet(self._forks)
+        return self._forks.value
+
+    @property
+    def forks_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._forks_url)
+        return self._forks_url.value
+
+    @property
+    def git_pull_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._git_pull_url)
+        return self._git_pull_url.value
+
+    @property
+    def git_push_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._git_push_url)
+        return self._git_push_url.value
+
+    @property
+    def history(self):
+        """
+        :type: list of :class:`GistHistoryState`
+        """
+        self._completeIfNotSet(self._history)
+        return self._history.value
+
+    @property
+    def html_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._html_url)
+        return self._html_url.value
+
+    @property
+    def id(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._id)
+        return self._id.value
+
+    @property
+    def owner(self):
+        """
+        :type: :class:`github.NamedUser.NamedUser`
+        """
+        self._completeIfNotSet(self._owner)
+        return self._owner.value
+
+    @property
+    def public(self):
+        """
+        :type: bool
+        """
+        self._completeIfNotSet(self._public)
+        return self._public.value
+
+    @property
+    def updated_at(self):
+        """
+        :type: datetime.datetime
+        """
+        self._completeIfNotSet(self._updated_at)
+        return self._updated_at.value
+
+    @property
+    def url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._url)
+        return self._url.value
+
+    @property
+    def user(self):
+        """
+        :type: :class:`github.NamedUser.NamedUser`
+        """
+        self._completeIfNotSet(self._user)
+        return self._user.value
+
+    @property
+    def version(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._version)
+        return self._version.value
+
+    def _initAttributes(self):
+        self._change_status = github.GithubObject.NotSet
+        self._comments = github.GithubObject.NotSet
+        self._comments_url = github.GithubObject.NotSet
+        self._commits_url = github.GithubObject.NotSet
+        self._committed_at = github.GithubObject.NotSet
+        self._created_at = github.GithubObject.NotSet
+        self._description = github.GithubObject.NotSet
+        self._files = github.GithubObject.NotSet
+        self._forks = github.GithubObject.NotSet
+        self._forks_url = github.GithubObject.NotSet
+        self._git_pull_url = github.GithubObject.NotSet
+        self._git_push_url = github.GithubObject.NotSet
+        self._history = github.GithubObject.NotSet
+        self._html_url = github.GithubObject.NotSet
+        self._id = github.GithubObject.NotSet
+        self._owner = github.GithubObject.NotSet
+        self._public = github.GithubObject.NotSet
+        self._updated_at = github.GithubObject.NotSet
+        self._url = github.GithubObject.NotSet
+        self._user = github.GithubObject.NotSet
+        self._version = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "change_status" in attributes:  # pragma no branch
+            self._change_status = self._makeClassAttribute(github.CommitStats.CommitStats, attributes["change_status"])
+        if "comments" in attributes:  # pragma no branch
+            self._comments = self._makeIntAttribute(attributes["comments"])
+        if "comments_url" in attributes:  # pragma no branch
+            self._comments_url = self._makeStringAttribute(attributes["comments_url"])
+        if "commits_url" in attributes:  # pragma no branch
+            self._commits_url = self._makeStringAttribute(attributes["commits_url"])
+        if "committed_at" in attributes:  # pragma no branch
+            self._committed_at = self._makeDatetimeAttribute(attributes["committed_at"])
+        if "created_at" in attributes:  # pragma no branch
+            self._created_at = self._makeDatetimeAttribute(attributes["created_at"])
+        if "description" in attributes:  # pragma no branch
+            self._description = self._makeStringAttribute(attributes["description"])
+        if "files" in attributes:  # pragma no branch
+            self._files = self._makeDictOfStringsToClassesAttribute(github.GistFile.GistFile, attributes["files"])
+        if "forks" in attributes:  # pragma no branch
+            self._forks = self._makeListOfClassesAttribute(github.Gist.Gist, attributes["forks"])
+        if "forks_url" in attributes:  # pragma no branch
+            self._forks_url = self._makeStringAttribute(attributes["forks_url"])
+        if "git_pull_url" in attributes:  # pragma no branch
+            self._git_pull_url = self._makeStringAttribute(attributes["git_pull_url"])
+        if "git_push_url" in attributes:  # pragma no branch
+            self._git_push_url = self._makeStringAttribute(attributes["git_push_url"])
+        if "history" in attributes:  # pragma no branch
+            self._history = self._makeListOfClassesAttribute(GistHistoryState, attributes["history"])
+        if "html_url" in attributes:  # pragma no branch
+            self._html_url = self._makeStringAttribute(attributes["html_url"])
+        if "id" in attributes:  # pragma no branch
+            self._id = self._makeStringAttribute(attributes["id"])
+        if "owner" in attributes:  # pragma no branch
+            self._owner = self._makeClassAttribute(github.NamedUser.NamedUser, attributes["owner"])
+        if "public" in attributes:  # pragma no branch
+            self._public = self._makeBoolAttribute(attributes["public"])
+        if "updated_at" in attributes:  # pragma no branch
+            self._updated_at = self._makeDatetimeAttribute(attributes["updated_at"])
+        if "url" in attributes:  # pragma no branch
+            self._url = self._makeStringAttribute(attributes["url"])
+        if "user" in attributes:  # pragma no branch
+            self._user = self._makeClassAttribute(github.NamedUser.NamedUser, attributes["user"])
+        if "version" in attributes:  # pragma no branch
+            self._version = self._makeStringAttribute(attributes["version"])

--- a/github/GitAuthor.py
+++ b/github/GitAuthor.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+
+
+class GitAuthor(github.GithubObject.NonCompletableGithubObject):
+    """
+    This class represents GitAuthors as returned for example by http://developer.github.com/v3/todo
+    """
+
+    @property
+    def date(self):
+        """
+        :type: datetime.datetime
+        """
+        return self._date.value
+
+    @property
+    def email(self):
+        """
+        :type: string
+        """
+        return self._email.value
+
+    @property
+    def name(self):
+        """
+        :type: string
+        """
+        return self._name.value
+
+    def _initAttributes(self):
+        self._date = github.GithubObject.NotSet
+        self._email = github.GithubObject.NotSet
+        self._name = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "date" in attributes:  # pragma no branch
+            self._date = self._makeDatetimeAttribute(attributes["date"])
+        if "email" in attributes:  # pragma no branch
+            self._email = self._makeStringAttribute(attributes["email"])
+        if "name" in attributes:  # pragma no branch
+            self._name = self._makeStringAttribute(attributes["name"])

--- a/github/GitBlob.py
+++ b/github/GitBlob.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+
+
+class GitBlob(github.GithubObject.CompletableGithubObject):
+    """
+    This class represents GitBlobs as returned for example by http://developer.github.com/v3/todo
+    """
+
+    @property
+    def content(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._content)
+        return self._content.value
+
+    @property
+    def encoding(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._encoding)
+        return self._encoding.value
+
+    @property
+    def sha(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._sha)
+        return self._sha.value
+
+    @property
+    def size(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._size)
+        return self._size.value
+
+    @property
+    def url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._url)
+        return self._url.value
+
+    def _initAttributes(self):
+        self._content = github.GithubObject.NotSet
+        self._encoding = github.GithubObject.NotSet
+        self._sha = github.GithubObject.NotSet
+        self._size = github.GithubObject.NotSet
+        self._url = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "content" in attributes:  # pragma no branch
+            self._content = self._makeStringAttribute(attributes["content"])
+        if "encoding" in attributes:  # pragma no branch
+            self._encoding = self._makeStringAttribute(attributes["encoding"])
+        if "sha" in attributes:  # pragma no branch
+            self._sha = self._makeStringAttribute(attributes["sha"])
+        if "size" in attributes:  # pragma no branch
+            self._size = self._makeIntAttribute(attributes["size"])
+        if "url" in attributes:  # pragma no branch
+            self._url = self._makeStringAttribute(attributes["url"])

--- a/github/GitCommit.py
+++ b/github/GitCommit.py
@@ -1,0 +1,132 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+
+import github.GitAuthor
+import github.GitTree
+
+
+class GitCommit(github.GithubObject.CompletableGithubObject):
+    """
+    This class represents GitCommits as returned for example by http://developer.github.com/v3/todo
+    """
+
+    @property
+    def author(self):
+        """
+        :type: :class:`github.GitAuthor.GitAuthor`
+        """
+        self._completeIfNotSet(self._author)
+        return self._author.value
+
+    @property
+    def committer(self):
+        """
+        :type: :class:`github.GitAuthor.GitAuthor`
+        """
+        self._completeIfNotSet(self._committer)
+        return self._committer.value
+
+    @property
+    def html_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._html_url)
+        return self._html_url.value
+
+    @property
+    def message(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._message)
+        return self._message.value
+
+    @property
+    def parents(self):
+        """
+        :type: list of :class:`github.GitCommit.GitCommit`
+        """
+        self._completeIfNotSet(self._parents)
+        return self._parents.value
+
+    @property
+    def sha(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._sha)
+        return self._sha.value
+
+    @property
+    def tree(self):
+        """
+        :type: :class:`github.GitTree.GitTree`
+        """
+        self._completeIfNotSet(self._tree)
+        return self._tree.value
+
+    @property
+    def url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._url)
+        return self._url.value
+
+    @property
+    def _identity(self):
+        return self.sha
+
+    def _initAttributes(self):
+        self._author = github.GithubObject.NotSet
+        self._committer = github.GithubObject.NotSet
+        self._html_url = github.GithubObject.NotSet
+        self._message = github.GithubObject.NotSet
+        self._parents = github.GithubObject.NotSet
+        self._sha = github.GithubObject.NotSet
+        self._tree = github.GithubObject.NotSet
+        self._url = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "author" in attributes:  # pragma no branch
+            self._author = self._makeClassAttribute(github.GitAuthor.GitAuthor, attributes["author"])
+        if "committer" in attributes:  # pragma no branch
+            self._committer = self._makeClassAttribute(github.GitAuthor.GitAuthor, attributes["committer"])
+        if "html_url" in attributes:  # pragma no branch
+            self._html_url = self._makeStringAttribute(attributes["html_url"])
+        if "message" in attributes:  # pragma no branch
+            self._message = self._makeStringAttribute(attributes["message"])
+        if "parents" in attributes:  # pragma no branch
+            self._parents = self._makeListOfClassesAttribute(GitCommit, attributes["parents"])
+        if "sha" in attributes:  # pragma no branch
+            self._sha = self._makeStringAttribute(attributes["sha"])
+        if "tree" in attributes:  # pragma no branch
+            self._tree = self._makeClassAttribute(github.GitTree.GitTree, attributes["tree"])
+        if "url" in attributes:  # pragma no branch
+            self._url = self._makeStringAttribute(attributes["url"])

--- a/github/GitObject.py
+++ b/github/GitObject.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+
+
+class GitObject(github.GithubObject.NonCompletableGithubObject):
+    """
+    This class represents GitObjects as returned for example by http://developer.github.com/v3/todo
+    """
+
+    @property
+    def sha(self):
+        """
+        :type: string
+        """
+        return self._sha.value
+
+    @property
+    def type(self):
+        """
+        :type: string
+        """
+        return self._type.value
+
+    @property
+    def url(self):
+        """
+        :type: string
+        """
+        return self._url.value
+
+    def _initAttributes(self):
+        self._sha = github.GithubObject.NotSet
+        self._type = github.GithubObject.NotSet
+        self._url = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "sha" in attributes:  # pragma no branch
+            self._sha = self._makeStringAttribute(attributes["sha"])
+        if "type" in attributes:  # pragma no branch
+            self._type = self._makeStringAttribute(attributes["type"])
+        if "url" in attributes:  # pragma no branch
+            self._url = self._makeStringAttribute(attributes["url"])

--- a/github/GitRef.py
+++ b/github/GitRef.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+
+import github.GitObject
+
+
+class GitRef(github.GithubObject.CompletableGithubObject):
+    """
+    This class represents GitRefs as returned for example by http://developer.github.com/v3/todo
+    """
+
+    @property
+    def object(self):
+        """
+        :type: :class:`github.GitObject.GitObject`
+        """
+        self._completeIfNotSet(self._object)
+        return self._object.value
+
+    @property
+    def ref(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._ref)
+        return self._ref.value
+
+    @property
+    def url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._url)
+        return self._url.value
+
+    def delete(self):
+        """
+        :calls: `DELETE /repos/:owner/:repo/git/refs/:ref <http://developer.github.com/v3/git/refs>`_
+        :rtype: None
+        """
+        headers, data = self._requester.requestJsonAndCheck(
+            "DELETE",
+            self.url
+        )
+
+    def edit(self, sha, force=github.GithubObject.NotSet):
+        """
+        :calls: `PATCH /repos/:owner/:repo/git/refs/:ref <http://developer.github.com/v3/git/refs>`_
+        :param sha: string
+        :param force: bool
+        :rtype: None
+        """
+        assert isinstance(sha, (str, unicode)), sha
+        assert force is github.GithubObject.NotSet or isinstance(force, bool), force
+        post_parameters = {
+            "sha": sha,
+        }
+        if force is not github.GithubObject.NotSet:
+            post_parameters["force"] = force
+        headers, data = self._requester.requestJsonAndCheck(
+            "PATCH",
+            self.url,
+            input=post_parameters
+        )
+        self._useAttributes(data)
+
+    def _initAttributes(self):
+        self._object = github.GithubObject.NotSet
+        self._ref = github.GithubObject.NotSet
+        self._url = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "object" in attributes:  # pragma no branch
+            self._object = self._makeClassAttribute(github.GitObject.GitObject, attributes["object"])
+        if "ref" in attributes:  # pragma no branch
+            self._ref = self._makeStringAttribute(attributes["ref"])
+        if "url" in attributes:  # pragma no branch
+            self._url = self._makeStringAttribute(attributes["url"])

--- a/github/GitRelease.py
+++ b/github/GitRelease.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2015 Ed Holland <eholland@alertlogic.com>                          #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+import github.GitAuthor
+
+
+class GitRelease(github.GithubObject.CompletableGithubObject):
+    """
+    This class represents GitRelease as returned for example by https://developer.github.com/v3/repos/releases
+    """
+
+    @property
+    def body(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._body)
+        return self._body.value
+
+    @property
+    def title(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._title)
+        return self._title.value
+
+    @property
+    def tag_name(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._tag_name)
+        return self._tag_name.value
+
+    @property
+    def author(self):
+        """
+        :type: :class:`github.GitAuthor.GitAuthor`
+        """
+        self._completeIfNotSet(self._author)
+        return self._author.value
+
+    @property
+    def url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._url)
+        return self._url.value
+
+    @property
+    def upload_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._upload_url)
+        return self._upload_url.value
+
+    def delete_release(self):
+        headers, data = self._requester.requestJsonAndCheck(
+            "DELETE",
+            self.url
+        )
+        return True
+
+    def update_release(self, name, message, draft=False, prerelease=False):
+        assert isinstance(name, (str, unicode)), name
+        assert isinstance(message, (str, unicode)), message
+        assert isinstance(draft, bool), draft
+        assert isinstance(prerelease, bool), prerelease
+        post_parameters = {
+            "tag_name": self.tag_name,
+            "name": name,
+            "body": message,
+            "draft": draft,
+            "prerelease": prerelease,
+        }
+        headers, data = self._requester.requestJsonAndCheck(
+            "PATCH",
+            self.url,
+            input=post_parameters
+        )
+        return github.GitRelease.GitRelease(self._requester, headers, data, completed=True)
+
+    def _initAttributes(self):
+        self._body = github.GithubObject.NotSet
+        self._title = github.GithubObject.NotSet
+        self._tag_name = github.GithubObject.NotSet
+        self._author = github.GithubObject.NotSet
+        self._url = github.GithubObject.NotSet
+        self._upload_url = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "body" in attributes:
+            self._body = self._makeStringAttribute(attributes["body"])
+        if "name" in attributes:
+            self._title = self._makeStringAttribute(attributes["name"])
+        if "tag_name" in attributes:
+            self._tag_name = self._makeStringAttribute(attributes["tag_name"])
+        if "author" in attributes:
+            self._author = self._makeClassAttribute(github.GitAuthor.GitAuthor, attributes["author"])
+        if "url" in attributes:
+            self._url = self._makeStringAttribute(attributes["url"])
+        if "upload_url" in attributes:
+            self._upload_url = self._makeStringAttribute(attributes["upload_url"])

--- a/github/GitTag.py
+++ b/github/GitTag.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+
+import github.GitAuthor
+import github.GitObject
+
+
+class GitTag(github.GithubObject.CompletableGithubObject):
+    """
+    This class represents GitTags as returned for example by http://developer.github.com/v3/todo
+    """
+
+    @property
+    def message(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._message)
+        return self._message.value
+
+    @property
+    def object(self):
+        """
+        :type: :class:`github.GitObject.GitObject`
+        """
+        self._completeIfNotSet(self._object)
+        return self._object.value
+
+    @property
+    def sha(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._sha)
+        return self._sha.value
+
+    @property
+    def tag(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._tag)
+        return self._tag.value
+
+    @property
+    def tagger(self):
+        """
+        :type: :class:`github.GitAuthor.GitAuthor`
+        """
+        self._completeIfNotSet(self._tagger)
+        return self._tagger.value
+
+    @property
+    def url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._url)
+        return self._url.value
+
+    def _initAttributes(self):
+        self._message = github.GithubObject.NotSet
+        self._object = github.GithubObject.NotSet
+        self._sha = github.GithubObject.NotSet
+        self._tag = github.GithubObject.NotSet
+        self._tagger = github.GithubObject.NotSet
+        self._url = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "message" in attributes:  # pragma no branch
+            self._message = self._makeStringAttribute(attributes["message"])
+        if "object" in attributes:  # pragma no branch
+            self._object = self._makeClassAttribute(github.GitObject.GitObject, attributes["object"])
+        if "sha" in attributes:  # pragma no branch
+            self._sha = self._makeStringAttribute(attributes["sha"])
+        if "tag" in attributes:  # pragma no branch
+            self._tag = self._makeStringAttribute(attributes["tag"])
+        if "tagger" in attributes:  # pragma no branch
+            self._tagger = self._makeClassAttribute(github.GitAuthor.GitAuthor, attributes["tagger"])
+        if "url" in attributes:  # pragma no branch
+            self._url = self._makeStringAttribute(attributes["url"])

--- a/github/GitTree.py
+++ b/github/GitTree.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+
+import github.GitTreeElement
+
+
+class GitTree(github.GithubObject.CompletableGithubObject):
+    """
+    This class represents GitTrees as returned for example by http://developer.github.com/v3/todo
+    """
+
+    @property
+    def sha(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._sha)
+        return self._sha.value
+
+    @property
+    def tree(self):
+        """
+        :type: list of :class:`github.GitTreeElement.GitTreeElement`
+        """
+        self._completeIfNotSet(self._tree)
+        return self._tree.value
+
+    @property
+    def url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._url)
+        return self._url.value
+
+    @property
+    def _identity(self):
+        return self.sha
+
+    def _initAttributes(self):
+        self._sha = github.GithubObject.NotSet
+        self._tree = github.GithubObject.NotSet
+        self._url = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "sha" in attributes:  # pragma no branch
+            self._sha = self._makeStringAttribute(attributes["sha"])
+        if "tree" in attributes:  # pragma no branch
+            self._tree = self._makeListOfClassesAttribute(github.GitTreeElement.GitTreeElement, attributes["tree"])
+        if "url" in attributes:  # pragma no branch
+            self._url = self._makeStringAttribute(attributes["url"])

--- a/github/GitTreeElement.py
+++ b/github/GitTreeElement.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+
+
+class GitTreeElement(github.GithubObject.NonCompletableGithubObject):
+    """
+    This class represents GitTreeElements as returned for example by http://developer.github.com/v3/todo
+    """
+
+    @property
+    def mode(self):
+        """
+        :type: string
+        """
+        return self._mode.value
+
+    @property
+    def path(self):
+        """
+        :type: string
+        """
+        return self._path.value
+
+    @property
+    def sha(self):
+        """
+        :type: string
+        """
+        return self._sha.value
+
+    @property
+    def size(self):
+        """
+        :type: integer
+        """
+        return self._size.value
+
+    @property
+    def type(self):
+        """
+        :type: string
+        """
+        return self._type.value
+
+    @property
+    def url(self):
+        """
+        :type: string
+        """
+        return self._url.value
+
+    def _initAttributes(self):
+        self._mode = github.GithubObject.NotSet
+        self._path = github.GithubObject.NotSet
+        self._sha = github.GithubObject.NotSet
+        self._size = github.GithubObject.NotSet
+        self._type = github.GithubObject.NotSet
+        self._url = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "mode" in attributes:  # pragma no branch
+            self._mode = self._makeStringAttribute(attributes["mode"])
+        if "path" in attributes:  # pragma no branch
+            self._path = self._makeStringAttribute(attributes["path"])
+        if "sha" in attributes:  # pragma no branch
+            self._sha = self._makeStringAttribute(attributes["sha"])
+        if "size" in attributes:  # pragma no branch
+            self._size = self._makeIntAttribute(attributes["size"])
+        if "type" in attributes:  # pragma no branch
+            self._type = self._makeStringAttribute(attributes["type"])
+        if "url" in attributes:  # pragma no branch
+            self._url = self._makeStringAttribute(attributes["url"])

--- a/github/GithubException.py
+++ b/github/GithubException.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+
+class GithubException(Exception):
+    """
+    Error handling in PyGithub is done with exceptions. This class is the base of all exceptions raised by PyGithub (but :class:`github.GithubException.BadAttributeException`).
+
+    Some other types of exceptions might be raised by underlying libraries, for example for network-related issues.
+    """
+
+    def __init__(self, status, data):
+        Exception.__init__(self)
+        self.__status = status
+        self.__data = data
+
+    @property
+    def status(self):
+        """
+        The status returned by the Github API
+        """
+        return self.__status
+
+    @property
+    def data(self):
+        """
+        The (decoded) data returned by the Github API
+        """
+        return self.__data
+
+    def __str__(self):
+        return str(self.status) + " " + str(self.data)
+
+
+class BadCredentialsException(GithubException):
+    """
+    Exception raised in case of bad credentials (when Github API replies with a 401 or 403 HTML status)
+    """
+
+
+class UnknownObjectException(GithubException):
+    """
+    Exception raised when a non-existing object is requested (when Github API replies with a 404 HTML status)
+    """
+
+
+class BadUserAgentException(GithubException):
+    """
+    Exception raised when request is sent with a bad user agent header (when Github API replies with a 403 bad user agent HTML status)
+    """
+
+
+class RateLimitExceededException(GithubException):
+    """
+    Exception raised when the rate limit is exceeded (when Github API replies with a 403 rate limit exceeded HTML status)
+    """
+
+
+class BadAttributeException(Exception):
+    """
+    Exception raised when Github returns an attribute with the wrong type.
+    """
+    def __init__(self, actualValue, expectedType, transformationException):
+        self.__actualValue = actualValue
+        self.__expectedType = expectedType
+        self.__transformationException = transformationException
+
+    @property
+    def actual_value(self):
+        """
+        The value returned by Github
+        """
+        return self.__actualValue
+
+    @property
+    def expected_type(self):
+        """
+        The type PyGithub expected
+        """
+        return self.__expectedType
+
+    @property
+    def transformation_exception(self):
+        """
+        The exception raised when PyGithub tried to parse the value
+        """
+        return self.__transformationException
+
+
+class TwoFactorException(GithubException):
+    """
+    Exception raised when Github requires a onetime password for two-factor authentication
+    """

--- a/github/GithubObject.py
+++ b/github/GithubObject.py
@@ -1,0 +1,264 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import datetime
+
+import GithubException
+import Consts
+
+
+class _NotSetType:
+    def __repr__(self):
+        return "NotSet"
+
+    value = None
+NotSet = _NotSetType()
+
+
+class _ValuedAttribute:
+    def __init__(self, value):
+        self.value = value
+
+
+class _BadAttribute:
+    def __init__(self, value, expectedType, exception=None):
+        self.__value = value
+        self.__expectedType = expectedType
+        self.__exception = exception
+
+    @property
+    def value(self):
+        raise GithubException.BadAttributeException(self.__value, self.__expectedType, self.__exception)
+
+
+class GithubObject(object):
+    """
+    Base class for all classes representing objects returned by the API.
+    """
+
+    '''
+    A global debug flag to enable header validation by requester for all objects
+    '''
+    CHECK_AFTER_INIT_FLAG = False
+
+    @classmethod
+    def setCheckAfterInitFlag(cls, flag):
+        cls.CHECK_AFTER_INIT_FLAG = flag
+
+    def __init__(self, requester, headers, attributes, completed):
+        self._requester = requester
+        self._initAttributes()
+        self._storeAndUseAttributes(headers, attributes)
+
+        # Ask requester to do some checking, for debug and test purpose
+        # Since it's most handy to access and kinda all-knowing
+        if self.CHECK_AFTER_INIT_FLAG:  # pragma no branch (Flag always set in tests)
+            requester.check_me(self)
+
+    def _storeAndUseAttributes(self, headers, attributes):
+        # Make sure headers are assigned before calling _useAttributes
+        # (Some derived classes will use headers in _useAttributes)
+        self._headers = headers
+        self._rawData = attributes
+        self._useAttributes(attributes)
+
+    @property
+    def raw_data(self):
+        """
+        :type: dict
+        """
+        self._completeIfNeeded()
+        return self._rawData
+
+    @property
+    def raw_headers(self):
+        """
+        :type: dict
+        """
+        self._completeIfNeeded()
+        return self._headers
+
+    @staticmethod
+    def _parentUrl(url):
+        return "/".join(url.split("/")[: -1])
+
+    @staticmethod
+    def __makeSimpleAttribute(value, type):
+        if value is None or isinstance(value, type):
+            return _ValuedAttribute(value)
+        else:
+            return _BadAttribute(value, type)
+
+    @staticmethod
+    def __makeSimpleListAttribute(value, type):
+        if isinstance(value, list) and all(isinstance(element, type) for element in value):
+            return _ValuedAttribute(value)
+        else:
+            return _BadAttribute(value, [type])
+
+    @staticmethod
+    def __makeTransformedAttribute(value, type, transform):
+        if value is None:
+            return _ValuedAttribute(None)
+        elif isinstance(value, type):
+            try:
+                return _ValuedAttribute(transform(value))
+            except Exception, e:
+                return _BadAttribute(value, type, e)
+        else:
+            return _BadAttribute(value, type)
+
+    @staticmethod
+    def _makeStringAttribute(value):
+        return GithubObject.__makeSimpleAttribute(value, (str, unicode))
+
+    @staticmethod
+    def _makeIntAttribute(value):
+        return GithubObject.__makeSimpleAttribute(value, (int, long))
+
+    @staticmethod
+    def _makeBoolAttribute(value):
+        return GithubObject.__makeSimpleAttribute(value, bool)
+
+    @staticmethod
+    def _makeDictAttribute(value):
+        return GithubObject.__makeSimpleAttribute(value, dict)
+
+    @staticmethod
+    def _makeTimestampAttribute(value):
+        return GithubObject.__makeTransformedAttribute(value, (int, long), datetime.datetime.utcfromtimestamp)
+
+    @staticmethod
+    def _makeDatetimeAttribute(value):
+        def parseDatetime(s):
+            if len(s) == 24:  # pragma no branch (This branch was used only when creating a download)
+                # The Downloads API has been removed. I'm keeping this branch because I have no mean
+                # to check if it's really useless now.
+                return datetime.datetime.strptime(s, "%Y-%m-%dT%H:%M:%S.000Z")  # pragma no cover (This branch was used only when creating a download)
+            elif len(s) == 25:
+                return datetime.datetime.strptime(s[:19], "%Y-%m-%dT%H:%M:%S") + (1 if s[19] == '-' else -1) * datetime.timedelta(hours=int(s[20:22]), minutes=int(s[23:25]))
+            else:
+                return datetime.datetime.strptime(s, "%Y-%m-%dT%H:%M:%SZ")
+
+        return GithubObject.__makeTransformedAttribute(value, (str, unicode), parseDatetime)
+
+    def _makeClassAttribute(self, klass, value):
+        return GithubObject.__makeTransformedAttribute(value, dict, lambda value: klass(self._requester, self._headers, value, completed=False))
+
+    @staticmethod
+    def _makeListOfStringsAttribute(value):
+        return GithubObject.__makeSimpleListAttribute(value, (str, unicode))
+
+    @staticmethod
+    def _makeListOfIntsAttribute(value):
+        return GithubObject.__makeSimpleListAttribute(value, int)
+
+    @staticmethod
+    def _makeListOfListOfStringsAttribute(value):
+        return GithubObject.__makeSimpleListAttribute(value, list)
+
+    def _makeListOfClassesAttribute(self, klass, value):
+        if isinstance(value, list) and all(isinstance(element, dict) for element in value):
+            return _ValuedAttribute([klass(self._requester, self._headers, element, completed=False) for element in value])
+        else:
+            return _BadAttribute(value, [dict])
+
+    def _makeDictOfStringsToClassesAttribute(self, klass, value):
+        if isinstance(value, dict) and all(isinstance(key, (str, unicode)) and isinstance(element, dict) for key, element in value.iteritems()):
+            return _ValuedAttribute(dict((key, klass(self._requester, self._headers, element, completed=False)) for key, element in value.iteritems()))
+        else:
+            return _BadAttribute(value, {(str, unicode): dict})
+
+    @property
+    def etag(self):
+        '''
+        :type: str
+        '''
+        return self._headers.get(Consts.RES_ETAG)
+
+    @property
+    def last_modified(self):
+        '''
+        :type: str
+        '''
+        return self._headers.get(Consts.RES_LAST_MODIFED)
+
+
+class NonCompletableGithubObject(GithubObject):
+    def _completeIfNeeded(self):
+        pass
+
+
+class CompletableGithubObject(GithubObject):
+    def __init__(self, requester, headers, attributes, completed):
+        GithubObject.__init__(self, requester, headers, attributes, completed)
+        self.__completed = completed
+
+    def __eq__(self, other):
+        return other.__class__ is self.__class__ and other._url.value == self._url.value
+
+    def __ne__(self, other):
+        return not self == other
+
+    def _completeIfNotSet(self, value):
+        if value is NotSet:
+            self._completeIfNeeded()
+
+    def _completeIfNeeded(self):
+        if not self.__completed:
+            self.__complete()
+
+    def __complete(self):
+        headers, data = self._requester.requestJsonAndCheck(
+            "GET",
+            self._url.value
+        )
+        self._storeAndUseAttributes(headers, data)
+        self.__completed = True
+
+    def update(self):
+        '''
+        Check and update the object with conditional request
+        :rtype: Boolean value indicating whether the object is changed
+        '''
+        conditionalRequestHeader = dict()
+        if self.etag is not None:
+            conditionalRequestHeader[Consts.REQ_IF_NONE_MATCH] = self.etag
+        if self.last_modified is not None:
+            conditionalRequestHeader[Consts.REQ_IF_MODIFIED_SINCE] = self.last_modified
+
+        status, responseHeaders, output = self._requester.requestJson(
+            "GET",
+            self._url.value,
+            headers=conditionalRequestHeader
+        )
+        if status == 304:
+            return False
+        else:
+            headers, data = self._requester._Requester__check(status, responseHeaders, output)
+            self._storeAndUseAttributes(headers, data)
+            self.__completed = True
+            return True

--- a/github/GitignoreTemplate.py
+++ b/github/GitignoreTemplate.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+
+
+class GitignoreTemplate(github.GithubObject.NonCompletableGithubObject):
+    """
+    This class represents GitignoreTemplates as returned for example by http://developer.github.com/v3/todo
+    """
+
+    @property
+    def source(self):
+        """
+        :type: string
+        """
+        return self._source.value
+
+    @property
+    def name(self):
+        """
+        :type: string
+        """
+        return self._name.value
+
+    def _initAttributes(self):
+        self._source = github.GithubObject.NotSet
+        self._name = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "source" in attributes:  # pragma no branch
+            self._source = self._makeStringAttribute(attributes["source"])
+        if "name" in attributes:  # pragma no branch
+            self._name = self._makeStringAttribute(attributes["name"])

--- a/github/Hook.py
+++ b/github/Hook.py
@@ -1,0 +1,205 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+
+import github.HookResponse
+
+
+class Hook(github.GithubObject.CompletableGithubObject):
+    """
+    This class represents Hooks as returned for example by http://developer.github.com/v3/repos/hooks
+    """
+
+    @property
+    def active(self):
+        """
+        :type: bool
+        """
+        self._completeIfNotSet(self._active)
+        return self._active.value
+
+    @property
+    def config(self):
+        """
+        :type: dict
+        """
+        self._completeIfNotSet(self._config)
+        return self._config.value
+
+    @property
+    def created_at(self):
+        """
+        :type: datetime.datetime
+        """
+        self._completeIfNotSet(self._created_at)
+        return self._created_at.value
+
+    @property
+    def events(self):
+        """
+        :type: list of string
+        """
+        self._completeIfNotSet(self._events)
+        return self._events.value
+
+    @property
+    def id(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._id)
+        return self._id.value
+
+    @property
+    def last_response(self):
+        """
+        :type: :class:`github.HookResponse.HookResponse`
+        """
+        self._completeIfNotSet(self._last_response)
+        return self._last_response.value
+
+    @property
+    def name(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._name)
+        return self._name.value
+
+    @property
+    def test_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._test_url)
+        return self._test_url.value
+
+    @property
+    def updated_at(self):
+        """
+        :type: datetime.datetime
+        """
+        self._completeIfNotSet(self._updated_at)
+        return self._updated_at.value
+
+    @property
+    def url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._url)
+        return self._url.value
+
+    def delete(self):
+        """
+        :calls: `DELETE /repos/:owner/:repo/hooks/:id <http://developer.github.com/v3/repos/hooks>`_
+        :rtype: None
+        """
+        headers, data = self._requester.requestJsonAndCheck(
+            "DELETE",
+            self.url
+        )
+
+    def edit(self, name, config, events=github.GithubObject.NotSet, add_events=github.GithubObject.NotSet, remove_events=github.GithubObject.NotSet, active=github.GithubObject.NotSet):
+        """
+        :calls: `PATCH /repos/:owner/:repo/hooks/:id <http://developer.github.com/v3/repos/hooks>`_
+        :param name: string
+        :param config: dict
+        :param events: list of string
+        :param add_events: list of string
+        :param remove_events: list of string
+        :param active: bool
+        :rtype: None
+        """
+        assert isinstance(name, (str, unicode)), name
+        assert isinstance(config, dict), config
+        assert events is github.GithubObject.NotSet or all(isinstance(element, (str, unicode)) for element in events), events
+        assert add_events is github.GithubObject.NotSet or all(isinstance(element, (str, unicode)) for element in add_events), add_events
+        assert remove_events is github.GithubObject.NotSet or all(isinstance(element, (str, unicode)) for element in remove_events), remove_events
+        assert active is github.GithubObject.NotSet or isinstance(active, bool), active
+        post_parameters = {
+            "name": name,
+            "config": config,
+        }
+        if events is not github.GithubObject.NotSet:
+            post_parameters["events"] = events
+        if add_events is not github.GithubObject.NotSet:
+            post_parameters["add_events"] = add_events
+        if remove_events is not github.GithubObject.NotSet:
+            post_parameters["remove_events"] = remove_events
+        if active is not github.GithubObject.NotSet:
+            post_parameters["active"] = active
+        headers, data = self._requester.requestJsonAndCheck(
+            "PATCH",
+            self.url,
+            input=post_parameters
+        )
+        self._useAttributes(data)
+
+    def test(self):
+        """
+        :calls: `POST /repos/:owner/:repo/hooks/:id/tests <http://developer.github.com/v3/repos/hooks>`_
+        :rtype: None
+        """
+        headers, data = self._requester.requestJsonAndCheck(
+            "POST",
+            self.url + "/tests"
+        )
+
+    def _initAttributes(self):
+        self._active = github.GithubObject.NotSet
+        self._config = github.GithubObject.NotSet
+        self._created_at = github.GithubObject.NotSet
+        self._events = github.GithubObject.NotSet
+        self._id = github.GithubObject.NotSet
+        self._last_response = github.GithubObject.NotSet
+        self._name = github.GithubObject.NotSet
+        self._test_url = github.GithubObject.NotSet
+        self._updated_at = github.GithubObject.NotSet
+        self._url = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "active" in attributes:  # pragma no branch
+            self._active = self._makeBoolAttribute(attributes["active"])
+        if "config" in attributes:  # pragma no branch
+            self._config = self._makeDictAttribute(attributes["config"])
+        if "created_at" in attributes:  # pragma no branch
+            self._created_at = self._makeDatetimeAttribute(attributes["created_at"])
+        if "events" in attributes:  # pragma no branch
+            self._events = self._makeListOfStringsAttribute(attributes["events"])
+        if "id" in attributes:  # pragma no branch
+            self._id = self._makeIntAttribute(attributes["id"])
+        if "last_response" in attributes:  # pragma no branch
+            self._last_response = self._makeClassAttribute(github.HookResponse.HookResponse, attributes["last_response"])
+        if "name" in attributes:  # pragma no branch
+            self._name = self._makeStringAttribute(attributes["name"])
+        if "test_url" in attributes:  # pragma no branch
+            self._test_url = self._makeStringAttribute(attributes["test_url"])
+        if "updated_at" in attributes:  # pragma no branch
+            self._updated_at = self._makeDatetimeAttribute(attributes["updated_at"])
+        if "url" in attributes:  # pragma no branch
+            self._url = self._makeStringAttribute(attributes["url"])

--- a/github/HookDescription.py
+++ b/github/HookDescription.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+
+
+class HookDescription(github.GithubObject.NonCompletableGithubObject):
+    """
+    This class represents HookDescriptions as returned for example by http://developer.github.com/v3/todo
+    """
+
+    @property
+    def events(self):
+        """
+        :type: list of string
+        """
+        return self._events.value
+
+    @property
+    def name(self):
+        """
+        :type: string
+        """
+        return self._name.value
+
+    @property
+    def schema(self):
+        """
+        :type: list of list of string
+        """
+        return self._schema.value
+
+    @property
+    def supported_events(self):
+        """
+        :type: list of string
+        """
+        return self._supported_events.value
+
+    def _initAttributes(self):
+        self._events = github.GithubObject.NotSet
+        self._name = github.GithubObject.NotSet
+        self._schema = github.GithubObject.NotSet
+        self._supported_events = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "events" in attributes:  # pragma no branch
+            self._events = self._makeListOfStringsAttribute(attributes["events"])
+        if "name" in attributes:  # pragma no branch
+            self._name = self._makeStringAttribute(attributes["name"])
+        if "schema" in attributes:  # pragma no branch
+            self._schema = self._makeListOfListOfStringsAttribute(attributes["schema"])
+        if "supported_events" in attributes:  # pragma no branch
+            self._supported_events = self._makeListOfStringsAttribute(attributes["supported_events"])

--- a/github/HookResponse.py
+++ b/github/HookResponse.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+
+
+class HookResponse(github.GithubObject.NonCompletableGithubObject):
+    """
+    This class represents HookResponses as returned for example by http://developer.github.com/v3/todo
+    """
+
+    @property
+    def code(self):
+        """
+        :type: integer
+        """
+        return self._code.value
+
+    @property
+    def message(self):
+        """
+        :type: string
+        """
+        return self._message.value
+
+    @property
+    def status(self):
+        """
+        :type: string
+        """
+        return self._status.value
+
+    def _initAttributes(self):
+        self._code = github.GithubObject.NotSet
+        self._message = github.GithubObject.NotSet
+        self._status = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "code" in attributes:  # pragma no branch
+            self._code = self._makeIntAttribute(attributes["code"])
+        if "message" in attributes:  # pragma no branch
+            self._message = self._makeStringAttribute(attributes["message"])
+        if "status" in attributes:  # pragma no branch
+            self._status = self._makeStringAttribute(attributes["status"])

--- a/github/InputFileContent.py
+++ b/github/InputFileContent.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+
+
+class InputFileContent(object):
+    """
+    """
+
+    def __init__(self, content, new_name=github.GithubObject.NotSet):
+        """
+        :param content: string
+        :param new_name: string
+        """
+
+        assert isinstance(content, (str, unicode)), content
+        assert new_name is github.GithubObject.NotSet or isinstance(new_name, (str, unicode)), new_name
+        self.__newName = new_name
+        self.__content = content
+
+    @property
+    def _identity(self):
+        identity = {
+            "content": self.__content,
+        }
+        if self.__newName is not github.GithubObject.NotSet:
+            identity["filename"] = self.__newName
+        return identity

--- a/github/InputGitAuthor.py
+++ b/github/InputGitAuthor.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+
+
+class InputGitAuthor(object):
+    """
+    """
+
+    def __init__(self, name, email, date=github.GithubObject.NotSet):
+        """
+        :param name: string
+        :param email: string
+        :param date: string
+        """
+
+        assert isinstance(name, (str, unicode)), name
+        assert isinstance(email, (str, unicode)), email
+        assert date is github.GithubObject.NotSet or isinstance(date, (str, unicode)), date  # @todo Datetime?
+
+        self.__name = name
+        self.__email = email
+        self.__date = date
+
+    @property
+    def _identity(self):
+        identity = {
+            "name": self.__name,
+            "email": self.__email,
+        }
+        if self.__date is not github.GithubObject.NotSet:
+            identity["date"] = self.__date
+        return identity

--- a/github/InputGitTreeElement.py
+++ b/github/InputGitTreeElement.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+
+
+class InputGitTreeElement(object):
+    """
+    """
+
+    def __init__(self, path, mode, type, content=github.GithubObject.NotSet, sha=github.GithubObject.NotSet):
+        """
+        :param path: string
+        :param mode: string
+        :param type: string
+        :param content: string
+        :param sha: string
+        """
+
+        assert isinstance(path, (str, unicode)), path
+        assert isinstance(mode, (str, unicode)), mode
+        assert isinstance(type, (str, unicode)), type
+        assert content is github.GithubObject.NotSet or isinstance(content, (str, unicode)), content
+        assert sha is github.GithubObject.NotSet or isinstance(sha, (str, unicode)), sha
+        self.__path = path
+        self.__mode = mode
+        self.__type = type
+        self.__content = content
+        self.__sha = sha
+
+    @property
+    def _identity(self):
+        identity = {
+            "path": self.__path,
+            "mode": self.__mode,
+            "type": self.__type,
+        }
+        if self.__sha is not github.GithubObject.NotSet:
+            identity["sha"] = self.__sha
+        if self.__content is not github.GithubObject.NotSet:
+            identity["content"] = self.__content
+        return identity

--- a/github/Issue.py
+++ b/github/Issue.py
@@ -1,0 +1,449 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Andrew Bettison <andrewb@zip.com.au>                          #
+# Copyright 2012 Philip Kimmey <philip@rover.com>                              #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Stuart Glaser <stuglaser@gmail.com>                           #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import urllib
+import github.GithubObject
+import github.PaginatedList
+
+import github.Repository
+import github.IssueEvent
+import github.Label
+import github.NamedUser
+import github.Milestone
+import github.IssueComment
+import github.IssuePullRequest
+
+
+class Issue(github.GithubObject.CompletableGithubObject):
+    """
+    This class represents Issues as returned for example by http://developer.github.com/v3/todo
+    """
+
+    @property
+    def assignee(self):
+        """
+        :type: :class:`github.NamedUser.NamedUser`
+        """
+        self._completeIfNotSet(self._assignee)
+        return self._assignee.value
+
+    @property
+    def body(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._body)
+        return self._body.value
+
+    @property
+    def closed_at(self):
+        """
+        :type: datetime.datetime
+        """
+        self._completeIfNotSet(self._closed_at)
+        return self._closed_at.value
+
+    @property
+    def closed_by(self):
+        """
+        :type: :class:`github.NamedUser.NamedUser`
+        """
+        self._completeIfNotSet(self._closed_by)
+        return self._closed_by.value
+
+    @property
+    def comments(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._comments)
+        return self._comments.value
+
+    @property
+    def comments_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._comments_url)
+        return self._comments_url.value
+
+    @property
+    def created_at(self):
+        """
+        :type: datetime.datetime
+        """
+        self._completeIfNotSet(self._created_at)
+        return self._created_at.value
+
+    @property
+    def events_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._events_url)
+        return self._events_url.value
+
+    @property
+    def html_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._html_url)
+        return self._html_url.value
+
+    @property
+    def id(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._id)
+        return self._id.value
+
+    @property
+    def labels(self):
+        """
+        :type: list of :class:`github.Label.Label`
+        """
+        self._completeIfNotSet(self._labels)
+        return self._labels.value
+
+    @property
+    def labels_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._labels_url)
+        return self._labels_url.value
+
+    @property
+    def milestone(self):
+        """
+        :type: :class:`github.Milestone.Milestone`
+        """
+        self._completeIfNotSet(self._milestone)
+        return self._milestone.value
+
+    @property
+    def number(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._number)
+        return self._number.value
+
+    @property
+    def pull_request(self):
+        """
+        :type: :class:`github.IssuePullRequest.IssuePullRequest`
+        """
+        self._completeIfNotSet(self._pull_request)
+        return self._pull_request.value
+
+    @property
+    def repository(self):
+        """
+        :type: :class:`github.Repository.Repository`
+        """
+        self._completeIfNotSet(self._repository)
+        if self._repository is github.GithubObject.NotSet:
+            # The repository was not set automatically, so it must be looked up by url.
+            repo_url = "/".join(self.url.split("/")[:-2])
+            self._repository = github.GithubObject._ValuedAttribute(github.Repository.Repository(self._requester, self._headers, {'url': repo_url}, completed=False))
+        return self._repository.value
+
+    @property
+    def state(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._state)
+        return self._state.value
+
+    @property
+    def title(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._title)
+        return self._title.value
+
+    @property
+    def updated_at(self):
+        """
+        :type: datetime.datetime
+        """
+        self._completeIfNotSet(self._updated_at)
+        return self._updated_at.value
+
+    @property
+    def url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._url)
+        return self._url.value
+
+    @property
+    def user(self):
+        """
+        :type: :class:`github.NamedUser.NamedUser`
+        """
+        self._completeIfNotSet(self._user)
+        return self._user.value
+
+    def add_to_labels(self, *labels):
+        """
+        :calls: `POST /repos/:owner/:repo/issues/:number/labels <http://developer.github.com/v3/issues/labels>`_
+        :param label: :class:`github.Label.Label` or string
+        :rtype: None
+        """
+        assert all(isinstance(element, (github.Label.Label, str, unicode)) for element in labels), labels
+        post_parameters = [label.name if isinstance(label, github.Label.Label) else label for label in labels]
+        headers, data = self._requester.requestJsonAndCheck(
+            "POST",
+            self.url + "/labels",
+            input=post_parameters
+        )
+
+    def create_comment(self, body):
+        """
+        :calls: `POST /repos/:owner/:repo/issues/:number/comments <http://developer.github.com/v3/issues/comments>`_
+        :param body: string
+        :rtype: :class:`github.IssueComment.IssueComment`
+        """
+        assert isinstance(body, (str, unicode)), body
+        post_parameters = {
+            "body": body,
+        }
+        headers, data = self._requester.requestJsonAndCheck(
+            "POST",
+            self.url + "/comments",
+            input=post_parameters
+        )
+        return github.IssueComment.IssueComment(self._requester, headers, data, completed=True)
+
+    def delete_labels(self):
+        """
+        :calls: `DELETE /repos/:owner/:repo/issues/:number/labels <http://developer.github.com/v3/issues/labels>`_
+        :rtype: None
+        """
+        headers, data = self._requester.requestJsonAndCheck(
+            "DELETE",
+            self.url + "/labels"
+        )
+
+    def edit(self, title=github.GithubObject.NotSet, body=github.GithubObject.NotSet, assignee=github.GithubObject.NotSet, state=github.GithubObject.NotSet, milestone=github.GithubObject.NotSet, labels=github.GithubObject.NotSet):
+        """
+        :calls: `PATCH /repos/:owner/:repo/issues/:number <http://developer.github.com/v3/issues>`_
+        :param title: string
+        :param body: string
+        :param assignee: string or :class:`github.NamedUser.NamedUser` or None
+        :param state: string
+        :param milestone: :class:`github.Milestone.Milestone` or None
+        :param labels: list of string
+        :rtype: None
+        """
+        assert title is github.GithubObject.NotSet or isinstance(title, (str, unicode)), title
+        assert body is github.GithubObject.NotSet or isinstance(body, (str, unicode)), body
+        assert assignee is github.GithubObject.NotSet or assignee is None or isinstance(assignee, github.NamedUser.NamedUser) or isinstance(assignee, (str, unicode)), assignee
+        assert state is github.GithubObject.NotSet or isinstance(state, (str, unicode)), state
+        assert milestone is github.GithubObject.NotSet or milestone is None or isinstance(milestone, github.Milestone.Milestone), milestone
+        assert labels is github.GithubObject.NotSet or all(isinstance(element, (str, unicode)) for element in labels), labels
+        post_parameters = dict()
+        if title is not github.GithubObject.NotSet:
+            post_parameters["title"] = title
+        if body is not github.GithubObject.NotSet:
+            post_parameters["body"] = body
+        if assignee is not github.GithubObject.NotSet:
+            if isinstance(assignee, (str, unicode)):
+                post_parameters["assignee"] = assignee
+            else:
+                post_parameters["assignee"] = assignee._identity if assignee else ''
+        if state is not github.GithubObject.NotSet:
+            post_parameters["state"] = state
+        if milestone is not github.GithubObject.NotSet:
+            post_parameters["milestone"] = milestone._identity if milestone else ''
+        if labels is not github.GithubObject.NotSet:
+            post_parameters["labels"] = labels
+        headers, data = self._requester.requestJsonAndCheck(
+            "PATCH",
+            self.url,
+            input=post_parameters
+        )
+        self._useAttributes(data)
+
+    def get_comment(self, id):
+        """
+        :calls: `GET /repos/:owner/:repo/issues/comments/:id <http://developer.github.com/v3/issues/comments>`_
+        :param id: integer
+        :rtype: :class:`github.IssueComment.IssueComment`
+        """
+        assert isinstance(id, (int, long)), id
+        headers, data = self._requester.requestJsonAndCheck(
+            "GET",
+            self._parentUrl(self.url) + "/comments/" + str(id)
+        )
+        return github.IssueComment.IssueComment(self._requester, headers, data, completed=True)
+
+    def get_comments(self):
+        """
+        :calls: `GET /repos/:owner/:repo/issues/:number/comments <http://developer.github.com/v3/issues/comments>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.IssueComment.IssueComment`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.IssueComment.IssueComment,
+            self._requester,
+            self.url + "/comments",
+            None
+        )
+
+    def get_events(self):
+        """
+        :calls: `GET /repos/:owner/:repo/issues/:issue_number/events <http://developer.github.com/v3/issues/events>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.IssueEvent.IssueEvent`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.IssueEvent.IssueEvent,
+            self._requester,
+            self.url + "/events",
+            None
+        )
+
+    def get_labels(self):
+        """
+        :calls: `GET /repos/:owner/:repo/issues/:number/labels <http://developer.github.com/v3/issues/labels>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Label.Label`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.Label.Label,
+            self._requester,
+            self.url + "/labels",
+            None
+        )
+
+    def remove_from_labels(self, label):
+        """
+        :calls: `DELETE /repos/:owner/:repo/issues/:number/labels/:name <http://developer.github.com/v3/issues/labels>`_
+        :param label: :class:`github.Label.Label` or string
+        :rtype: None
+        """
+        assert isinstance(label, (github.Label.Label, str, unicode)), label
+        if isinstance(label, github.Label.Label):
+            label = label._identity
+        else:
+            label = urllib.quote(label)
+        headers, data = self._requester.requestJsonAndCheck(
+            "DELETE",
+            self.url + "/labels/" + label
+        )
+
+    def set_labels(self, *labels):
+        """
+        :calls: `PUT /repos/:owner/:repo/issues/:number/labels <http://developer.github.com/v3/issues/labels>`_
+        :param label: :class:`github.Label.Label`
+        :rtype: None
+        """
+        assert all(isinstance(element, (github.Label.Label, str, unicode)) for element in labels), labels
+        post_parameters = [label.name if isinstance(label, github.Label.Label) else label for label in labels]
+        headers, data = self._requester.requestJsonAndCheck(
+            "PUT",
+            self.url + "/labels",
+            input=post_parameters
+        )
+
+    @property
+    def _identity(self):
+        return self.number
+
+    def _initAttributes(self):
+        self._assignee = github.GithubObject.NotSet
+        self._body = github.GithubObject.NotSet
+        self._closed_at = github.GithubObject.NotSet
+        self._closed_by = github.GithubObject.NotSet
+        self._comments = github.GithubObject.NotSet
+        self._comments_url = github.GithubObject.NotSet
+        self._created_at = github.GithubObject.NotSet
+        self._events_url = github.GithubObject.NotSet
+        self._html_url = github.GithubObject.NotSet
+        self._id = github.GithubObject.NotSet
+        self._labels = github.GithubObject.NotSet
+        self._labels_url = github.GithubObject.NotSet
+        self._milestone = github.GithubObject.NotSet
+        self._number = github.GithubObject.NotSet
+        self._pull_request = github.GithubObject.NotSet
+        self._repository = github.GithubObject.NotSet
+        self._state = github.GithubObject.NotSet
+        self._title = github.GithubObject.NotSet
+        self._updated_at = github.GithubObject.NotSet
+        self._url = github.GithubObject.NotSet
+        self._user = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "assignee" in attributes:  # pragma no branch
+            self._assignee = self._makeClassAttribute(github.NamedUser.NamedUser, attributes["assignee"])
+        if "body" in attributes:  # pragma no branch
+            self._body = self._makeStringAttribute(attributes["body"])
+        if "closed_at" in attributes:  # pragma no branch
+            self._closed_at = self._makeDatetimeAttribute(attributes["closed_at"])
+        if "closed_by" in attributes:  # pragma no branch
+            self._closed_by = self._makeClassAttribute(github.NamedUser.NamedUser, attributes["closed_by"])
+        if "comments" in attributes:  # pragma no branch
+            self._comments = self._makeIntAttribute(attributes["comments"])
+        if "comments_url" in attributes:  # pragma no branch
+            self._comments_url = self._makeStringAttribute(attributes["comments_url"])
+        if "created_at" in attributes:  # pragma no branch
+            self._created_at = self._makeDatetimeAttribute(attributes["created_at"])
+        if "events_url" in attributes:  # pragma no branch
+            self._events_url = self._makeStringAttribute(attributes["events_url"])
+        if "html_url" in attributes:  # pragma no branch
+            self._html_url = self._makeStringAttribute(attributes["html_url"])
+        if "id" in attributes:  # pragma no branch
+            self._id = self._makeIntAttribute(attributes["id"])
+        if "labels" in attributes:  # pragma no branch
+            self._labels = self._makeListOfClassesAttribute(github.Label.Label, attributes["labels"])
+        if "labels_url" in attributes:  # pragma no branch
+            self._labels_url = self._makeStringAttribute(attributes["labels_url"])
+        if "milestone" in attributes:  # pragma no branch
+            self._milestone = self._makeClassAttribute(github.Milestone.Milestone, attributes["milestone"])
+        if "number" in attributes:  # pragma no branch
+            self._number = self._makeIntAttribute(attributes["number"])
+        if "pull_request" in attributes:  # pragma no branch
+            self._pull_request = self._makeClassAttribute(github.IssuePullRequest.IssuePullRequest, attributes["pull_request"])
+        if "repository" in attributes:  # pragma no branch
+            self._repository = self._makeClassAttribute(github.Repository.Repository, attributes["repository"])
+        if "state" in attributes:  # pragma no branch
+            self._state = self._makeStringAttribute(attributes["state"])
+        if "title" in attributes:  # pragma no branch
+            self._title = self._makeStringAttribute(attributes["title"])
+        if "updated_at" in attributes:  # pragma no branch
+            self._updated_at = self._makeDatetimeAttribute(attributes["updated_at"])
+        if "url" in attributes:  # pragma no branch
+            self._url = self._makeStringAttribute(attributes["url"])
+        if "user" in attributes:  # pragma no branch
+            self._user = self._makeClassAttribute(github.NamedUser.NamedUser, attributes["user"])

--- a/github/IssueComment.py
+++ b/github/IssueComment.py
@@ -1,0 +1,155 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Michael Stead <michael.stead@gmail.com>                       #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+
+import github.NamedUser
+
+
+class IssueComment(github.GithubObject.CompletableGithubObject):
+    """
+    This class represents IssueComments as returned for example by http://developer.github.com/v3/todo
+    """
+
+    @property
+    def body(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._body)
+        return self._body.value
+
+    @property
+    def created_at(self):
+        """
+        :type: datetime.datetime
+        """
+        self._completeIfNotSet(self._created_at)
+        return self._created_at.value
+
+    @property
+    def id(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._id)
+        return self._id.value
+
+    @property
+    def issue_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._issue_url)
+        return self._issue_url.value
+
+    @property
+    def updated_at(self):
+        """
+        :type: datetime.datetime
+        """
+        self._completeIfNotSet(self._updated_at)
+        return self._updated_at.value
+
+    @property
+    def url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._url)
+        return self._url.value
+
+    @property
+    def html_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._html_url)
+        return self._html_url.value
+
+    @property
+    def user(self):
+        """
+        :type: :class:`github.NamedUser.NamedUser`
+        """
+        self._completeIfNotSet(self._user)
+        return self._user.value
+
+    def delete(self):
+        """
+        :calls: `DELETE /repos/:owner/:repo/issues/comments/:id <http://developer.github.com/v3/issues/comments>`_
+        :rtype: None
+        """
+        headers, data = self._requester.requestJsonAndCheck(
+            "DELETE",
+            self.url
+        )
+
+    def edit(self, body):
+        """
+        :calls: `PATCH /repos/:owner/:repo/issues/comments/:id <http://developer.github.com/v3/issues/comments>`_
+        :param body: string
+        :rtype: None
+        """
+        assert isinstance(body, (str, unicode)), body
+        post_parameters = {
+            "body": body,
+        }
+        headers, data = self._requester.requestJsonAndCheck(
+            "PATCH",
+            self.url,
+            input=post_parameters
+        )
+        self._useAttributes(data)
+
+    def _initAttributes(self):
+        self._body = github.GithubObject.NotSet
+        self._created_at = github.GithubObject.NotSet
+        self._id = github.GithubObject.NotSet
+        self._issue_url = github.GithubObject.NotSet
+        self._updated_at = github.GithubObject.NotSet
+        self._url = github.GithubObject.NotSet
+        self._html_url = github.GithubObject.NotSet
+        self._user = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "body" in attributes:  # pragma no branch
+            self._body = self._makeStringAttribute(attributes["body"])
+        if "created_at" in attributes:  # pragma no branch
+            self._created_at = self._makeDatetimeAttribute(attributes["created_at"])
+        if "id" in attributes:  # pragma no branch
+            self._id = self._makeIntAttribute(attributes["id"])
+        if "issue_url" in attributes:  # pragma no branch
+            self._issue_url = self._makeStringAttribute(attributes["issue_url"])
+        if "updated_at" in attributes:  # pragma no branch
+            self._updated_at = self._makeDatetimeAttribute(attributes["updated_at"])
+        if "url" in attributes:  # pragma no branch
+            self._url = self._makeStringAttribute(attributes["url"])
+        if "html_url" in attributes:  # pragma no branch
+            self._html_url = self._makeStringAttribute(attributes["html_url"])
+        if "user" in attributes:  # pragma no branch
+            self._user = self._makeClassAttribute(github.NamedUser.NamedUser, attributes["user"])

--- a/github/IssueEvent.py
+++ b/github/IssueEvent.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+
+import github.Issue
+import github.NamedUser
+
+
+class IssueEvent(github.GithubObject.CompletableGithubObject):
+    """
+    This class represents IssueEvents as returned for example by http://developer.github.com/v3/todo
+    """
+
+    @property
+    def actor(self):
+        """
+        :type: :class:`github.NamedUser.NamedUser`
+        """
+        self._completeIfNotSet(self._actor)
+        return self._actor.value
+
+    @property
+    def commit_id(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._commit_id)
+        return self._commit_id.value
+
+    @property
+    def created_at(self):
+        """
+        :type: datetime.datetime
+        """
+        self._completeIfNotSet(self._created_at)
+        return self._created_at.value
+
+    @property
+    def event(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._event)
+        return self._event.value
+
+    @property
+    def id(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._id)
+        return self._id.value
+
+    @property
+    def issue(self):
+        """
+        :type: :class:`github.Issue.Issue`
+        """
+        self._completeIfNotSet(self._issue)
+        return self._issue.value
+
+    @property
+    def url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._url)
+        return self._url.value
+
+    def _initAttributes(self):
+        self._actor = github.GithubObject.NotSet
+        self._commit_id = github.GithubObject.NotSet
+        self._created_at = github.GithubObject.NotSet
+        self._event = github.GithubObject.NotSet
+        self._id = github.GithubObject.NotSet
+        self._issue = github.GithubObject.NotSet
+        self._url = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "actor" in attributes:  # pragma no branch
+            self._actor = self._makeClassAttribute(github.NamedUser.NamedUser, attributes["actor"])
+        if "commit_id" in attributes:  # pragma no branch
+            self._commit_id = self._makeStringAttribute(attributes["commit_id"])
+        if "created_at" in attributes:  # pragma no branch
+            self._created_at = self._makeDatetimeAttribute(attributes["created_at"])
+        if "event" in attributes:  # pragma no branch
+            self._event = self._makeStringAttribute(attributes["event"])
+        if "id" in attributes:  # pragma no branch
+            self._id = self._makeIntAttribute(attributes["id"])
+        if "issue" in attributes:  # pragma no branch
+            self._issue = self._makeClassAttribute(github.Issue.Issue, attributes["issue"])
+        if "url" in attributes:  # pragma no branch
+            self._url = self._makeStringAttribute(attributes["url"])

--- a/github/IssuePullRequest.py
+++ b/github/IssuePullRequest.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+
+
+class IssuePullRequest(github.GithubObject.NonCompletableGithubObject):
+    """
+    This class represents IssuePullRequests as returned for example by http://developer.github.com/v3/todo
+    """
+
+    @property
+    def diff_url(self):
+        """
+        :type: string
+        """
+        return self._diff_url.value
+
+    @property
+    def html_url(self):
+        """
+        :type: string
+        """
+        return self._html_url.value
+
+    @property
+    def patch_url(self):
+        """
+        :type: string
+        """
+        return self._patch_url.value
+
+    def _initAttributes(self):
+        self._diff_url = github.GithubObject.NotSet
+        self._html_url = github.GithubObject.NotSet
+        self._patch_url = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "diff_url" in attributes:  # pragma no branch
+            self._diff_url = self._makeStringAttribute(attributes["diff_url"])
+        if "html_url" in attributes:  # pragma no branch
+            self._html_url = self._makeStringAttribute(attributes["html_url"])
+        if "patch_url" in attributes:  # pragma no branch
+            self._patch_url = self._makeStringAttribute(attributes["patch_url"])

--- a/github/Label.py
+++ b/github/Label.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2013 martinqt <m.ki2@laposte.net>                                  #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import urllib
+
+import github.GithubObject
+
+
+class Label(github.GithubObject.CompletableGithubObject):
+    """
+    This class represents Labels. The reference can be found here http://developer.github.com/v3/issues/labels/
+    """
+
+    @property
+    def color(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._color)
+        return self._color.value
+
+    @property
+    def name(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._name)
+        return self._name.value
+
+    @property
+    def url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._url)
+        return self._url.value
+
+    def delete(self):
+        """
+        :calls: `DELETE /repos/:owner/:repo/labels/:name <http://developer.github.com/v3/issues/labels>`_
+        :rtype: None
+        """
+        headers, data = self._requester.requestJsonAndCheck(
+            "DELETE",
+            self.url
+        )
+
+    def edit(self, name, color):
+        """
+        :calls: `PATCH /repos/:owner/:repo/labels/:name <http://developer.github.com/v3/issues/labels>`_
+        :param name: string
+        :param color: string
+        :rtype: None
+        """
+        assert isinstance(name, (str, unicode)), name
+        assert isinstance(color, (str, unicode)), color
+        post_parameters = {
+            "name": name,
+            "color": color,
+        }
+        headers, data = self._requester.requestJsonAndCheck(
+            "PATCH",
+            self.url,
+            input=post_parameters
+        )
+        self._useAttributes(data)
+
+    @property
+    def _identity(self):
+        return urllib.quote(self.name)
+
+    def _initAttributes(self):
+        self._color = github.GithubObject.NotSet
+        self._name = github.GithubObject.NotSet
+        self._url = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "color" in attributes:  # pragma no branch
+            self._color = self._makeStringAttribute(attributes["color"])
+        if "name" in attributes:  # pragma no branch
+            self._name = self._makeStringAttribute(attributes["name"])
+        if "url" in attributes:  # pragma no branch
+            self._url = self._makeStringAttribute(attributes["url"])

--- a/github/Legacy.py
+++ b/github/Legacy.py
@@ -1,0 +1,149 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Steve English <steve.english@navetas.com>                     #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import urlparse
+
+import github.PaginatedList
+
+
+class PaginatedList(github.PaginatedList.PaginatedListBase):
+    def __init__(self, url, args, requester, key, convert, contentClass):
+        github.PaginatedList.PaginatedListBase.__init__(self)
+        self.__url = url
+        self.__args = args
+        self.__requester = requester
+        self.__key = key
+        self.__convert = convert
+        self.__contentClass = contentClass
+        self.__nextPage = 0
+        self.__continue = True
+
+    def _couldGrow(self):
+        return self.__continue
+
+    def _fetchNextPage(self):
+        page = self.__nextPage
+        self.__nextPage += 1
+        return self.get_page(page)
+
+    def get_page(self, page):
+        assert isinstance(page, (int, long)), page
+        args = dict(self.__args)
+        if page != 0:
+            args["start_page"] = page + 1
+        headers, data = self.__requester.requestJsonAndCheck(
+            "GET",
+            self.__url,
+            parameters=args
+        )
+        self.__continue = len(data[self.__key]) > 0
+
+        return [
+            self.__contentClass(self.__requester, headers, self.__convert(element), completed=False)
+            for element in data[self.__key]
+        ]
+
+
+def convertUser(attributes):
+    convertedAttributes = {
+        "login": attributes["login"],
+        "url": "/users/" + attributes["login"],
+    }
+    if "gravatar_id" in attributes:  # pragma no branch
+        convertedAttributes["gravatar_id"] = attributes["gravatar_id"]
+    if "followers" in attributes:  # pragma no branch
+        convertedAttributes["followers"] = attributes["followers"]
+    if "repos" in attributes:  # pragma no branch
+        convertedAttributes["public_repos"] = attributes["repos"]
+    if "name" in attributes:  # pragma no branch
+        convertedAttributes["name"] = attributes["name"]
+    if "created_at" in attributes:  # pragma no branch
+        convertedAttributes["created_at"] = attributes["created_at"]
+    if "location" in attributes:  # pragma no branch
+        convertedAttributes["location"] = attributes["location"]
+    return convertedAttributes
+
+
+def convertRepo(attributes):
+    convertedAttributes = {
+        "owner": {"login": attributes["owner"], "url": "/users/" + attributes["owner"]},
+        "url": "/repos/" + attributes["owner"] + "/" + attributes["name"],
+    }
+    if "pushed_at" in attributes:  # pragma no branch
+        convertedAttributes["pushed_at"] = attributes["pushed_at"]
+    if "homepage" in attributes:  # pragma no branch
+        convertedAttributes["homepage"] = attributes["homepage"]
+    if "created_at" in attributes:  # pragma no branch
+        convertedAttributes["created_at"] = attributes["created_at"]
+    if "watchers" in attributes:  # pragma no branch
+        convertedAttributes["watchers"] = attributes["watchers"]
+    if "has_downloads" in attributes:  # pragma no branch
+        convertedAttributes["has_downloads"] = attributes["has_downloads"]
+    if "fork" in attributes:  # pragma no branch
+        convertedAttributes["fork"] = attributes["fork"]
+    if "has_issues" in attributes:  # pragma no branch
+        convertedAttributes["has_issues"] = attributes["has_issues"]
+    if "has_wiki" in attributes:  # pragma no branch
+        convertedAttributes["has_wiki"] = attributes["has_wiki"]
+    if "forks" in attributes:  # pragma no branch
+        convertedAttributes["forks"] = attributes["forks"]
+    if "size" in attributes:  # pragma no branch
+        convertedAttributes["size"] = attributes["size"]
+    if "private" in attributes:  # pragma no branch
+        convertedAttributes["private"] = attributes["private"]
+    if "open_issues" in attributes:  # pragma no branch
+        convertedAttributes["open_issues"] = attributes["open_issues"]
+    if "description" in attributes:  # pragma no branch
+        convertedAttributes["description"] = attributes["description"]
+    if "language" in attributes:  # pragma no branch
+        convertedAttributes["language"] = attributes["language"]
+    if "name" in attributes:  # pragma no branch
+        convertedAttributes["name"] = attributes["name"]
+    return convertedAttributes
+
+
+def convertIssue(attributes):
+    convertedAttributes = {
+        "number": attributes["number"],
+        "url": "/repos" + urlparse.urlparse(attributes["html_url"]).path,
+        "user": {"login": attributes["user"], "url": "/users/" + attributes["user"]},
+    }
+    if "labels" in attributes:  # pragma no branch
+        convertedAttributes["labels"] = [{"name": label} for label in attributes["labels"]]
+    if "title" in attributes:  # pragma no branch
+        convertedAttributes["title"] = attributes["title"]
+    if "created_at" in attributes:  # pragma no branch
+        convertedAttributes["created_at"] = attributes["created_at"]
+    if "comments" in attributes:  # pragma no branch
+        convertedAttributes["comments"] = attributes["comments"]
+    if "body" in attributes:  # pragma no branch
+        convertedAttributes["body"] = attributes["body"]
+    if "updated_at" in attributes:  # pragma no branch
+        convertedAttributes["updated_at"] = attributes["updated_at"]
+    if "state" in attributes:  # pragma no branch
+        convertedAttributes["state"] = attributes["state"]
+    return convertedAttributes

--- a/github/MainClass.py
+++ b/github/MainClass.py
@@ -1,0 +1,591 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Ed Jackson <ed.jackson@gmail.com>                             #
+# Copyright 2013 Jonathan J Hunt <hunt@braincorporation.com>                   #
+# Copyright 2013 Peter Golm <golm.peter@gmail.com>                             #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import urllib
+import pickle
+
+from Requester import Requester
+import AuthenticatedUser
+import NamedUser
+import Organization
+import Gist
+import github.PaginatedList
+import Repository
+import Legacy
+import github.GithubObject
+import HookDescription
+import GitignoreTemplate
+import Status
+import StatusMessage
+import RateLimit
+
+
+DEFAULT_BASE_URL = "https://api.github.com"
+DEFAULT_TIMEOUT = 10
+DEFAULT_PER_PAGE = 30
+
+
+class Github(object):
+    """
+    This is the main class you instanciate to access the Github API v3. Optional parameters allow different authentication methods.
+    """
+
+    def __init__(self, login_or_token=None, password=None, base_url=DEFAULT_BASE_URL, timeout=DEFAULT_TIMEOUT, client_id=None, client_secret=None, user_agent='PyGithub/Python', per_page=DEFAULT_PER_PAGE, api_preview=False):
+        """
+        :param login_or_token: string
+        :param password: string
+        :param base_url: string
+        :param timeout: integer
+        :param client_id: string
+        :param client_secret: string
+        :param user_agent: string
+        :param per_page: int
+        """
+
+        assert login_or_token is None or isinstance(login_or_token, (str, unicode)), login_or_token
+        assert password is None or isinstance(password, (str, unicode)), password
+        assert isinstance(base_url, (str, unicode)), base_url
+        assert isinstance(timeout, (int, long)), timeout
+        assert client_id is None or isinstance(client_id, (str, unicode)), client_id
+        assert client_secret is None or isinstance(client_secret, (str, unicode)), client_secret
+        assert user_agent is None or isinstance(user_agent, (str, unicode)), user_agent
+        assert isinstance(api_preview, (bool))
+        self.__requester = Requester(login_or_token, password, base_url, timeout, client_id, client_secret, user_agent, per_page, api_preview)
+
+    def __get_FIX_REPO_GET_GIT_REF(self):
+        """
+        :type: bool
+        """
+        return self.__requester.FIX_REPO_GET_GIT_REF
+
+    def __set_FIX_REPO_GET_GIT_REF(self, value):
+        self.__requester.FIX_REPO_GET_GIT_REF = value
+
+    FIX_REPO_GET_GIT_REF = property(__get_FIX_REPO_GET_GIT_REF, __set_FIX_REPO_GET_GIT_REF)
+
+    def __get_per_page(self):
+        """
+        :type: int
+        """
+        return self.__requester.per_page
+
+    def __set_per_page(self, value):
+        self.__requester.per_page = value
+
+    # v2: Remove this property? Why should it be necessary to read/modify it after construction
+    per_page = property(__get_per_page, __set_per_page)
+
+    # v2: Provide a unified way to access values of headers of last response
+    # v2: (and add/keep ad hoc properties for specific useful headers like rate limiting, oauth scopes, etc.)
+    # v2: Return an instance of a class: using a tuple did not allow to add a field "resettime"
+    @property
+    def rate_limiting(self):
+        """
+        First value is requests remaining, second value is request limit.
+        :type: (int, int)
+        """
+        remaining, limit = self.__requester.rate_limiting
+        if limit < 0:
+            self.get_rate_limit()
+        return self.__requester.rate_limiting
+
+    @property
+    def rate_limiting_resettime(self):
+        """
+        Unix timestamp indicating when rate limiting will reset.
+        :type: int
+        """
+        if self.__requester.rate_limiting_resettime == 0:
+            self.get_rate_limit()
+        return self.__requester.rate_limiting_resettime
+
+    def get_rate_limit(self):
+        """
+        Don't forget you can access the rate limit returned in headers of last Github API v3 response, by :attr:`github.MainClass.Github.rate_limiting` and :attr:`github.MainClass.Github.rate_limiting_resettime`.
+
+        :calls: `GET /rate_limit <http://developer.github.com/v3/rate_limit>`_
+        :rtype: :class:`github.RateLimit.RateLimit`
+        """
+        headers, attributes = self.__requester.requestJsonAndCheck(
+            'GET',
+            '/rate_limit'
+        )
+        return RateLimit.RateLimit(self.__requester, headers, attributes, True)
+
+    @property
+    def oauth_scopes(self):
+        """
+        :type: list of string
+        """
+        return self.__requester.oauth_scopes
+
+    def get_user(self, login=github.GithubObject.NotSet):
+        """
+        :calls: `GET /users/:user <http://developer.github.com/v3/users>`_ or `GET /user <http://developer.github.com/v3/users>`_
+        :param login: string
+        :rtype: :class:`github.NamedUser.NamedUser`
+        """
+        assert login is github.GithubObject.NotSet or isinstance(login, (str, unicode)), login
+        if login is github.GithubObject.NotSet:
+            return AuthenticatedUser.AuthenticatedUser(self.__requester, {}, {"url": "/user"}, completed=False)
+        else:
+            headers, data = self.__requester.requestJsonAndCheck(
+                "GET",
+                "/users/" + login
+            )
+            return github.NamedUser.NamedUser(self.__requester, headers, data, completed=True)
+
+    def get_users(self, since=github.GithubObject.NotSet):
+        """
+        :calls: `GET /users <http://developer.github.com/v3/users>`_
+        :param since: integer
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.NamedUser.NamedUser`
+        """
+        assert since is github.GithubObject.NotSet or isinstance(since, (int, long)), since
+        url_parameters = dict()
+        if since is not github.GithubObject.NotSet:
+            url_parameters["since"] = since
+        return github.PaginatedList.PaginatedList(
+            github.NamedUser.NamedUser,
+            self.__requester,
+            "/users",
+            url_parameters
+        )
+
+    def get_organization(self, login):
+        """
+        :calls: `GET /orgs/:org <http://developer.github.com/v3/orgs>`_
+        :param login: string
+        :rtype: :class:`github.Organization.Organization`
+        """
+        assert isinstance(login, (str, unicode)), login
+        headers, data = self.__requester.requestJsonAndCheck(
+            "GET",
+            "/orgs/" + login
+        )
+        return github.Organization.Organization(self.__requester, headers, data, completed=True)
+
+    def get_repo(self, full_name_or_id, lazy=True):
+        """
+        :calls: `GET /repos/:owner/:repo <http://developer.github.com/v3/repos>`_ or `GET /repositories/:id <http://developer.github.com/v3/repos>`_
+        :rtype: :class:`github.Repository.Repository`
+        """
+        assert isinstance(full_name_or_id, (str, unicode, int, long)), full_name_or_id
+        url_base = "/repositories/" if isinstance(full_name_or_id, int) or isinstance(full_name_or_id, long) else "/repos/"
+        url = "%s%s" % (url_base, full_name_or_id)
+        if lazy:
+            return Repository.Repository(self.__requester, {}, {"url": url}, completed=False)
+        headers, data = self.__requester.requestJsonAndCheck(
+            "GET",
+            "%s%s" % (url_base, full_name_or_id)
+        )
+        return Repository.Repository(self.__requester, headers, data, completed=True)
+
+    def get_repos(self, since=github.GithubObject.NotSet):
+        """
+        :calls: `GET /repositories <http://developer.github.com/v3/repos/#list-all-public-repositories>`_
+        :param since: integer
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Repository.Repository`
+        """
+        assert since is github.GithubObject.NotSet or isinstance(since, (int, long)), since
+        url_parameters = dict()
+        if since is not github.GithubObject.NotSet:
+            url_parameters["since"] = since
+        return github.PaginatedList.PaginatedList(
+            github.Repository.Repository,
+            self.__requester,
+            "/repositories",
+            url_parameters
+        )
+
+    def get_gist(self, id):
+        """
+        :calls: `GET /gists/:id <http://developer.github.com/v3/gists>`_
+        :param id: string
+        :rtype: :class:`github.Gist.Gist`
+        """
+        assert isinstance(id, (str, unicode)), id
+        headers, data = self.__requester.requestJsonAndCheck(
+            "GET",
+            "/gists/" + id
+        )
+        return github.Gist.Gist(self.__requester, headers, data, completed=True)
+
+    def get_gists(self):
+        """
+        :calls: `GET /gists/public <http://developer.github.com/v3/gists>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Gist.Gist`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.Gist.Gist,
+            self.__requester,
+            "/gists/public",
+            None
+        )
+
+    def legacy_search_repos(self, keyword, language=github.GithubObject.NotSet):
+        """
+        :calls: `GET /legacy/repos/search/:keyword <http://developer.github.com/v3/search/legacy>`_
+        :param keyword: string
+        :param language: string
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Repository.Repository`
+        """
+        assert isinstance(keyword, (str, unicode)), keyword
+        assert language is github.GithubObject.NotSet or isinstance(language, (str, unicode)), language
+        args = {} if language is github.GithubObject.NotSet else {"language": language}
+        return Legacy.PaginatedList(
+            "/legacy/repos/search/" + urllib.quote_plus(keyword, safe='/%:><'),
+            args,
+            self.__requester,
+            "repositories",
+            Legacy.convertRepo,
+            github.Repository.Repository,
+        )
+
+    def legacy_search_users(self, keyword):
+        """
+        :calls: `GET /legacy/user/search/:keyword <http://developer.github.com/v3/search/legacy>`_
+        :param keyword: string
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.NamedUser.NamedUser`
+        """
+        assert isinstance(keyword, (str, unicode)), keyword
+        return Legacy.PaginatedList(
+            "/legacy/user/search/" + urllib.quote_plus(keyword, safe='/%:><'),
+            {},
+            self.__requester,
+            "users",
+            Legacy.convertUser,
+            github.NamedUser.NamedUser,
+        )
+
+    def legacy_search_user_by_email(self, email):
+        """
+        :calls: `GET /legacy/user/email/:email <http://developer.github.com/v3/search/legacy>`_
+        :param email: string
+        :rtype: :class:`github.NamedUser.NamedUser`
+        """
+        assert isinstance(email, (str, unicode)), email
+        headers, data = self.__requester.requestJsonAndCheck(
+            "GET",
+            "/legacy/user/email/" + email
+        )
+        return github.NamedUser.NamedUser(self.__requester, headers, Legacy.convertUser(data["user"]), completed=False)
+
+    def search_repositories(self, query, sort=github.GithubObject.NotSet, order=github.GithubObject.NotSet, **qualifiers):
+        """
+        :calls: `GET /search/repositories <http://developer.github.com/v3/search>`_
+        :param query: string
+        :param sort: string ('stars', 'forks', 'updated')
+        :param order: string ('asc', 'desc')
+        :param qualifiers: keyword dict query qualifiers
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Repository.Repository`
+        """
+        assert isinstance(query, (str, unicode)), query
+        url_parameters = dict()
+        if sort is not github.GithubObject.NotSet:  # pragma no branch (Should be covered)
+            assert sort in ('stars', 'forks', 'updated'), sort
+            url_parameters["sort"] = sort
+        if order is not github.GithubObject.NotSet:  # pragma no branch (Should be covered)
+            assert order in ('asc', 'desc'), order
+            url_parameters["order"] = order
+
+        query_chunks = []
+        if query:  # pragma no branch (Should be covered)
+            query_chunks.append(query)
+
+        for qualifier, value in qualifiers.items():
+            query_chunks.append("%s:%s" % (qualifier, value))
+
+        url_parameters["q"] = ' '.join(query_chunks)
+        assert url_parameters["q"], "need at least one qualifier"
+
+        return github.PaginatedList.PaginatedList(
+            github.Repository.Repository,
+            self.__requester,
+            "/search/repositories",
+            url_parameters
+        )
+
+    def search_users(self, query, sort=github.GithubObject.NotSet, order=github.GithubObject.NotSet, **qualifiers):
+        """
+        :calls: `GET /search/users <http://developer.github.com/v3/search>`_
+        :param query: string
+        :param sort: string ('followers', 'repositories', 'joined')
+        :param order: string ('asc', 'desc')
+        :param qualifiers: keyword dict query qualifiers
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.NamedUser.NamedUser`
+        """
+        assert isinstance(query, (str, unicode)), query
+        url_parameters = dict()
+        if sort is not github.GithubObject.NotSet:
+            assert sort in ('followers', 'repositories', 'joined'), sort
+            url_parameters["sort"] = sort
+        if order is not github.GithubObject.NotSet:
+            assert order in ('asc', 'desc'), order
+            url_parameters["order"] = order
+
+        query_chunks = []
+        if query:
+            query_chunks.append(query)
+
+        for qualifier, value in qualifiers.items():
+            query_chunks.append("%s:%s" % (qualifier, value))
+
+        url_parameters["q"] = ' '.join(query_chunks)
+        assert url_parameters["q"], "need at least one qualifier"
+
+        return github.PaginatedList.PaginatedList(
+            github.NamedUser.NamedUser,
+            self.__requester,
+            "/search/users",
+            url_parameters
+        )
+
+    def search_issues(self, query, sort=github.GithubObject.NotSet, order=github.GithubObject.NotSet, **qualifiers):
+        """
+        :calls: `GET /search/issues <http://developer.github.com/v3/search>`_
+        :param query: string
+        :param sort: string ('comments', 'created', 'updated')
+        :param order: string ('asc', 'desc')
+        :param qualifiers: keyword dict query qualifiers
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Issue.Issue`
+        """
+        assert isinstance(query, (str, unicode)), query
+        url_parameters = dict()
+        if sort is not github.GithubObject.NotSet:
+            assert sort in ('comments', 'created', 'updated'), sort
+            url_parameters["sort"] = sort
+        if order is not github.GithubObject.NotSet:
+            assert order in ('asc', 'desc'), order
+            url_parameters["order"] = order
+
+        query_chunks = []
+        if query:  # pragma no branch (Should be covered)
+            query_chunks.append(query)
+
+        for qualifier, value in qualifiers.items():
+            query_chunks.append("%s:%s" % (qualifier, value))
+
+        url_parameters["q"] = ' '.join(query_chunks)
+        assert url_parameters["q"], "need at least one qualifier"
+
+        return github.PaginatedList.PaginatedList(
+            github.Issue.Issue,
+            self.__requester,
+            "/search/issues",
+            url_parameters
+        )
+
+    def search_code(self, query, sort=github.GithubObject.NotSet, order=github.GithubObject.NotSet, **qualifiers):
+        """
+        :calls: `GET /search/code <http://developer.github.com/v3/search>`_
+        :param query: string
+        :param sort: string ('indexed')
+        :param order: string ('asc', 'desc')
+        :param qualifiers: keyword dict query qualifiers
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.ContentFile.ContentFile`
+        """
+        assert isinstance(query, (str, unicode)), query
+        url_parameters = dict()
+        if sort is not github.GithubObject.NotSet:  # pragma no branch (Should be covered)
+            assert sort in ('indexed',), sort
+            url_parameters["sort"] = sort
+        if order is not github.GithubObject.NotSet:  # pragma no branch (Should be covered)
+            assert order in ('asc', 'desc'), order
+            url_parameters["order"] = order
+
+        query_chunks = []
+        if query:  # pragma no branch (Should be covered)
+            query_chunks.append(query)
+
+        for qualifier, value in qualifiers.items():
+            query_chunks.append("%s:%s" % (qualifier, value))
+
+        url_parameters["q"] = ' '.join(query_chunks)
+        assert url_parameters["q"], "need at least one qualifier"
+
+        return github.PaginatedList.PaginatedList(
+            github.ContentFile.ContentFile,
+            self.__requester,
+            "/search/code",
+            url_parameters
+        )
+
+    def render_markdown(self, text, context=github.GithubObject.NotSet):
+        """
+        :calls: `POST /markdown <http://developer.github.com/v3/markdown>`_
+        :param text: string
+        :param context: :class:`github.Repository.Repository`
+        :rtype: string
+        """
+        assert isinstance(text, (str, unicode)), text
+        assert context is github.GithubObject.NotSet or isinstance(context, github.Repository.Repository), context
+        post_parameters = {
+            "text": text
+        }
+        if context is not github.GithubObject.NotSet:
+            post_parameters["mode"] = "gfm"
+            post_parameters["context"] = context._identity
+        status, headers, data = self.__requester.requestJson(
+            "POST",
+            "/markdown",
+            input=post_parameters
+        )
+        return data
+
+    def get_hook(self, name):
+        """
+        :calls: `GET /hooks/:name <http://developer.github.com/v3/repos/hooks/>`_
+        :param name: string
+        :rtype: :class:`github.HookDescription.HookDescription`
+        """
+        assert isinstance(name, (str, unicode)), name
+        headers, attributes = self.__requester.requestJsonAndCheck(
+            "GET",
+            "/hooks/" + name
+        )
+        return HookDescription.HookDescription(self.__requester, headers, attributes, completed=True)
+
+    def get_hooks(self):
+        """
+        :calls: `GET /hooks <http://developer.github.com/v3/repos/hooks/>`_
+        :rtype: list of :class:`github.HookDescription.HookDescription`
+        """
+        headers, data = self.__requester.requestJsonAndCheck(
+            "GET",
+            "/hooks"
+        )
+        return [HookDescription.HookDescription(self.__requester, headers, attributes, completed=True) for attributes in data]
+
+    def get_gitignore_templates(self):
+        """
+        :calls: `GET /gitignore/templates <http://developer.github.com/v3/gitignore>`_
+        :rtype: list of string
+        """
+        headers, data = self.__requester.requestJsonAndCheck(
+            "GET",
+            "/gitignore/templates"
+        )
+        return data
+
+    def get_gitignore_template(self, name):
+        """
+        :calls: `GET /gitignore/templates/:name <http://developer.github.com/v3/gitignore>`_
+        :rtype: :class:`github.GitignoreTemplate.GitignoreTemplate`
+        """
+        assert isinstance(name, (str, unicode)), name
+        headers, attributes = self.__requester.requestJsonAndCheck(
+            "GET",
+            "/gitignore/templates/" + name
+        )
+        return GitignoreTemplate.GitignoreTemplate(self.__requester, headers, attributes, completed=True)
+
+    def get_emojis(self):
+        """
+        :calls: `GET /emojis <http://developer.github.com/v3/emojis/>`_
+        :rtype: dictionary of type => url for emoji`
+        """
+        headers, attributes = self.__requester.requestJsonAndCheck(
+            "GET",
+            "/emojis"
+        )
+        return attributes
+
+    def create_from_raw_data(self, klass, raw_data, headers={}):
+        """
+        Creates an object from raw_data previously obtained by :attr:`github.GithubObject.GithubObject.raw_data`,
+        and optionaly headers previously obtained by :attr:`github.GithubObject.GithubObject.raw_headers`.
+
+        :param klass: the class of the object to create
+        :param raw_data: dict
+        :param headers: dict
+        :rtype: instance of class ``klass``
+        """
+        return klass(self.__requester, headers, raw_data, completed=True)
+
+    def dump(self, obj, file, protocol=0):
+        """
+        Dumps (pickles) a PyGithub object to a file-like object.
+        Some effort is made to not pickle sensitive informations like the Github credentials used in the :class:`Github` instance.
+        But NO EFFORT is made to remove sensitive information from the object's attributes.
+
+        :param obj: the object to pickle
+        :param file: the file-like object to pickle to
+        :param protocol: the `pickling protocol <http://docs.python.org/2.7/library/pickle.html#data-stream-format>`_
+        """
+        pickle.dump((obj.__class__, obj.raw_data, obj.raw_headers), file, protocol)
+
+    def load(self, f):
+        """
+        Loads (unpickles) a PyGithub object from a file-like object.
+
+        :param f: the file-like object to unpickle from
+        :return: the unpickled object
+        """
+        return self.create_from_raw_data(*pickle.load(f))
+
+    def get_api_status(self):
+        """
+        This doesn't work with a Github Enterprise installation, because it always targets https://status.github.com.
+
+        :calls: `GET /api/status.json <https://status.github.com/api>`_
+        :rtype: :class:`github.Status.Status`
+        """
+        headers, attributes = self.__requester.requestJsonAndCheck(
+            "GET",
+            "/api/status.json",
+            cnx="status"
+        )
+        return Status.Status(self.__requester, headers, attributes, completed=True)
+
+    def get_last_api_status_message(self):
+        """
+        This doesn't work with a Github Enterprise installation, because it always targets https://status.github.com.
+
+        :calls: `GET /api/last-message.json <https://status.github.com/api>`_
+        :rtype: :class:`github.StatusMessage.StatusMessage`
+        """
+        headers, attributes = self.__requester.requestJsonAndCheck(
+            "GET",
+            "/api/last-message.json",
+            cnx="status"
+        )
+        return StatusMessage.StatusMessage(self.__requester, headers, attributes, completed=True)
+
+    def get_api_status_messages(self):
+        """
+        This doesn't work with a Github Enterprise installation, because it always targets https://status.github.com.
+
+        :calls: `GET /api/messages.json <https://status.github.com/api>`_
+        :rtype: list of :class:`github.StatusMessage.StatusMessage`
+        """
+        headers, data = self.__requester.requestJsonAndCheck(
+            "GET",
+            "/api/messages.json",
+            cnx="status"
+        )
+        return [StatusMessage.StatusMessage(self.__requester, headers, attributes, completed=True) for attributes in data]

--- a/github/Milestone.py
+++ b/github/Milestone.py
@@ -1,0 +1,242 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2013 martinqt <m.ki2@laposte.net>                                  #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import datetime
+
+import github.GithubObject
+import github.PaginatedList
+
+import github.NamedUser
+import github.Label
+
+
+class Milestone(github.GithubObject.CompletableGithubObject):
+    """
+    This class represents Milestones. The reference can be found here http://developer.github.com/v3/issues/milestones/
+    """
+
+    @property
+    def closed_issues(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._closed_issues)
+        return self._closed_issues.value
+
+    @property
+    def created_at(self):
+        """
+        :type: datetime.datetime
+        """
+        self._completeIfNotSet(self._created_at)
+        return self._created_at.value
+
+    @property
+    def creator(self):
+        """
+        :type: :class:`github.NamedUser.NamedUser`
+        """
+        self._completeIfNotSet(self._creator)
+        return self._creator.value
+
+    @property
+    def description(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._description)
+        return self._description.value
+
+    @property
+    def due_on(self):
+        """
+        :type: datetime.datetime
+        """
+        self._completeIfNotSet(self._due_on)
+        return self._due_on.value
+
+    @property
+    def id(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._id)
+        return self._id.value
+
+    @property
+    def labels_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._labels_url)
+        return self._labels_url.value
+
+    @property
+    def number(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._number)
+        return self._number.value
+
+    @property
+    def open_issues(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._open_issues)
+        return self._open_issues.value
+
+    @property
+    def state(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._state)
+        return self._state.value
+
+    @property
+    def title(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._title)
+        return self._title.value
+
+    @property
+    def updated_at(self):
+        """
+        :type: datetime.datetime
+        """
+        self._completeIfNotSet(self._updated_at)
+        return self._updated_at.value
+
+    @property
+    def url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._url)
+        return self._url.value
+
+    def delete(self):
+        """
+        :calls: `DELETE /repos/:owner/:repo/milestones/:number <http://developer.github.com/v3/issues/milestones>`_
+        :rtype: None
+        """
+        headers, data = self._requester.requestJsonAndCheck(
+            "DELETE",
+            self.url
+        )
+
+    def edit(self, title, state=github.GithubObject.NotSet, description=github.GithubObject.NotSet, due_on=github.GithubObject.NotSet):
+        """
+        :calls: `PATCH /repos/:owner/:repo/milestones/:number <http://developer.github.com/v3/issues/milestones>`_
+        :param title: string
+        :param state: string
+        :param description: string
+        :param due_on: date
+        :rtype: None
+        """
+        assert isinstance(title, (str, unicode)), title
+        assert state is github.GithubObject.NotSet or isinstance(state, (str, unicode)), state
+        assert description is github.GithubObject.NotSet or isinstance(description, (str, unicode)), description
+        assert due_on is github.GithubObject.NotSet or isinstance(due_on, datetime.date), due_on
+        post_parameters = {
+            "title": title,
+        }
+        if state is not github.GithubObject.NotSet:
+            post_parameters["state"] = state
+        if description is not github.GithubObject.NotSet:
+            post_parameters["description"] = description
+        if due_on is not github.GithubObject.NotSet:
+            post_parameters["due_on"] = due_on.strftime("%Y-%m-%d")
+        headers, data = self._requester.requestJsonAndCheck(
+            "PATCH",
+            self.url,
+            input=post_parameters
+        )
+        self._useAttributes(data)
+
+    def get_labels(self):
+        """
+        :calls: `GET /repos/:owner/:repo/milestones/:number/labels <http://developer.github.com/v3/issues/labels>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Label.Label`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.Label.Label,
+            self._requester,
+            self.url + "/labels",
+            None
+        )
+
+    @property
+    def _identity(self):
+        return self.number
+
+    def _initAttributes(self):
+        self._closed_issues = github.GithubObject.NotSet
+        self._created_at = github.GithubObject.NotSet
+        self._creator = github.GithubObject.NotSet
+        self._description = github.GithubObject.NotSet
+        self._due_on = github.GithubObject.NotSet
+        self._id = github.GithubObject.NotSet
+        self._labels_url = github.GithubObject.NotSet
+        self._number = github.GithubObject.NotSet
+        self._open_issues = github.GithubObject.NotSet
+        self._state = github.GithubObject.NotSet
+        self._title = github.GithubObject.NotSet
+        self._updated_at = github.GithubObject.NotSet
+        self._url = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "closed_issues" in attributes:  # pragma no branch
+            self._closed_issues = self._makeIntAttribute(attributes["closed_issues"])
+        if "created_at" in attributes:  # pragma no branch
+            self._created_at = self._makeDatetimeAttribute(attributes["created_at"])
+        if "creator" in attributes:  # pragma no branch
+            self._creator = self._makeClassAttribute(github.NamedUser.NamedUser, attributes["creator"])
+        if "description" in attributes:  # pragma no branch
+            self._description = self._makeStringAttribute(attributes["description"])
+        if "due_on" in attributes:  # pragma no branch
+            self._due_on = self._makeDatetimeAttribute(attributes["due_on"])
+        if "id" in attributes:  # pragma no branch
+            self._id = self._makeIntAttribute(attributes["id"])
+        if "labels_url" in attributes:  # pragma no branch
+            self._labels_url = self._makeStringAttribute(attributes["labels_url"])
+        if "number" in attributes:  # pragma no branch
+            self._number = self._makeIntAttribute(attributes["number"])
+        if "open_issues" in attributes:  # pragma no branch
+            self._open_issues = self._makeIntAttribute(attributes["open_issues"])
+        if "state" in attributes:  # pragma no branch
+            self._state = self._makeStringAttribute(attributes["state"])
+        if "title" in attributes:  # pragma no branch
+            self._title = self._makeStringAttribute(attributes["title"])
+        if "updated_at" in attributes:  # pragma no branch
+            self._updated_at = self._makeDatetimeAttribute(attributes["updated_at"])
+        if "url" in attributes:  # pragma no branch
+            self._url = self._makeStringAttribute(attributes["url"])

--- a/github/NamedUser.py
+++ b/github/NamedUser.py
@@ -1,0 +1,633 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Steve English <steve.english@navetas.com>                     #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+import github.PaginatedList
+
+import github.Gist
+import github.Repository
+import github.NamedUser
+import github.Plan
+import github.Organization
+import github.Event
+
+
+class NamedUser(github.GithubObject.CompletableGithubObject):
+    """
+    This class represents NamedUsers as returned for example by http://developer.github.com/v3/todo
+    """
+
+    @property
+    def avatar_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._avatar_url)
+        return self._avatar_url.value
+
+    @property
+    def bio(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._bio)
+        return self._bio.value
+
+    @property
+    def blog(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._blog)
+        return self._blog.value
+
+    @property
+    def collaborators(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._collaborators)
+        return self._collaborators.value
+
+    @property
+    def company(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._company)
+        return self._company.value
+
+    @property
+    def contributions(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._contributions)
+        return self._contributions.value
+
+    @property
+    def created_at(self):
+        """
+        :type: datetime.datetime
+        """
+        self._completeIfNotSet(self._created_at)
+        return self._created_at.value
+
+    @property
+    def disk_usage(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._disk_usage)
+        return self._disk_usage.value
+
+    @property
+    def email(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._email)
+        return self._email.value
+
+    @property
+    def events_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._events_url)
+        return self._events_url.value
+
+    @property
+    def followers(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._followers)
+        return self._followers.value
+
+    @property
+    def followers_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._followers_url)
+        return self._followers_url.value
+
+    @property
+    def following(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._following)
+        return self._following.value
+
+    @property
+    def following_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._following_url)
+        return self._following_url.value
+
+    @property
+    def gists_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._gists_url)
+        return self._gists_url.value
+
+    @property
+    def gravatar_id(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._gravatar_id)
+        return self._gravatar_id.value
+
+    @property
+    def hireable(self):
+        """
+        :type: bool
+        """
+        self._completeIfNotSet(self._hireable)
+        return self._hireable.value
+
+    @property
+    def html_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._html_url)
+        return self._html_url.value
+
+    @property
+    def id(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._id)
+        return self._id.value
+
+    @property
+    def location(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._location)
+        return self._location.value
+
+    @property
+    def login(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._login)
+        return self._login.value
+
+    @property
+    def name(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._name)
+        return self._name.value
+
+    @property
+    def organizations_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._organizations_url)
+        return self._organizations_url.value
+
+    @property
+    def owned_private_repos(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._owned_private_repos)
+        return self._owned_private_repos.value
+
+    @property
+    def plan(self):
+        """
+        :type: :class:`github.Plan.Plan`
+        """
+        self._completeIfNotSet(self._plan)
+        return self._plan.value
+
+    @property
+    def private_gists(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._private_gists)
+        return self._private_gists.value
+
+    @property
+    def public_gists(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._public_gists)
+        return self._public_gists.value
+
+    @property
+    def public_repos(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._public_repos)
+        return self._public_repos.value
+
+    @property
+    def received_events_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._received_events_url)
+        return self._received_events_url.value
+
+    @property
+    def repos_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._repos_url)
+        return self._repos_url.value
+
+    @property
+    def starred_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._starred_url)
+        return self._starred_url.value
+
+    @property
+    def subscriptions_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._subscriptions_url)
+        return self._subscriptions_url.value
+
+    @property
+    def total_private_repos(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._total_private_repos)
+        return self._total_private_repos.value
+
+    @property
+    def type(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._type)
+        return self._type.value
+
+    @property
+    def updated_at(self):
+        """
+        :type: datetime.datetime
+        """
+        self._completeIfNotSet(self._updated_at)
+        return self._updated_at.value
+
+    @property
+    def url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._url)
+        return self._url.value
+
+    def get_events(self):
+        """
+        :calls: `GET /users/:user/events <http://developer.github.com/v3/activity/events>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Event.Event`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.Event.Event,
+            self._requester,
+            self.url + "/events",
+            None
+        )
+
+    def get_followers(self):
+        """
+        :calls: `GET /users/:user/followers <http://developer.github.com/v3/users/followers>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.NamedUser.NamedUser`
+        """
+        return github.PaginatedList.PaginatedList(
+            NamedUser,
+            self._requester,
+            self.url + "/followers",
+            None
+        )
+
+    def get_following(self):
+        """
+        :calls: `GET /users/:user/following <http://developer.github.com/v3/users/followers>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.NamedUser.NamedUser`
+        """
+        return github.PaginatedList.PaginatedList(
+            NamedUser,
+            self._requester,
+            self.url + "/following",
+            None
+        )
+
+    def get_gists(self):
+        """
+        :calls: `GET /users/:user/gists <http://developer.github.com/v3/gists>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Gist.Gist`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.Gist.Gist,
+            self._requester,
+            self.url + "/gists",
+            None
+        )
+
+    def get_keys(self):
+        """
+        :calls: `GET /users/:user/keys <http://developer.github.com/v3/users/keys>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.UserKey.UserKey`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.UserKey.UserKey,
+            self._requester,
+            self.url + "/keys",
+            None
+        )
+
+    def get_orgs(self):
+        """
+        :calls: `GET /users/:user/orgs <http://developer.github.com/v3/orgs>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Organization.Organization`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.Organization.Organization,
+            self._requester,
+            self.url + "/orgs",
+            None
+        )
+
+    def get_public_events(self):
+        """
+        :calls: `GET /users/:user/events/public <http://developer.github.com/v3/activity/events>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Event.Event`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.Event.Event,
+            self._requester,
+            self.url + "/events/public",
+            None
+        )
+
+    def get_public_received_events(self):
+        """
+        :calls: `GET /users/:user/received_events/public <http://developer.github.com/v3/activity/events>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Event.Event`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.Event.Event,
+            self._requester,
+            self.url + "/received_events/public",
+            None
+        )
+
+    def get_received_events(self):
+        """
+        :calls: `GET /users/:user/received_events <http://developer.github.com/v3/activity/events>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Event.Event`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.Event.Event,
+            self._requester,
+            self.url + "/received_events",
+            None
+        )
+
+    def get_repo(self, name):
+        """
+        :calls: `GET /repos/:owner/:repo <http://developer.github.com/v3/repos>`_
+        :param name: string
+        :rtype: :class:`github.Repository.Repository`
+        """
+        assert isinstance(name, (str, unicode)), name
+        headers, data = self._requester.requestJsonAndCheck(
+            "GET",
+            "/repos/" + self.login + "/" + name
+        )
+        return github.Repository.Repository(self._requester, headers, data, completed=True)
+
+    def get_repos(self, type=github.GithubObject.NotSet):
+        """
+        :calls: `GET /users/:user/repos <http://developer.github.com/v3/repos>`_
+        :param type: string
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Repository.Repository`
+        """
+        assert type is github.GithubObject.NotSet or isinstance(type, (str, unicode)), type
+        url_parameters = dict()
+        if type is not github.GithubObject.NotSet:
+            url_parameters["type"] = type
+        return github.PaginatedList.PaginatedList(
+            github.Repository.Repository,
+            self._requester,
+            self.url + "/repos",
+            url_parameters
+        )
+
+    def get_starred(self):
+        """
+        :calls: `GET /users/:user/starred <http://developer.github.com/v3/activity/starring>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Repository.Repository`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.Repository.Repository,
+            self._requester,
+            self.url + "/starred",
+            None
+        )
+
+    def get_subscriptions(self):
+        """
+        :calls: `GET /users/:user/subscriptions <http://developer.github.com/v3/activity/watching>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Repository.Repository`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.Repository.Repository,
+            self._requester,
+            self.url + "/subscriptions",
+            None
+        )
+
+    def get_watched(self):
+        """
+        :calls: `GET /users/:user/watched <http://developer.github.com/v3/activity/starring>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Repository.Repository`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.Repository.Repository,
+            self._requester,
+            self.url + "/watched",
+            None
+        )
+
+    def has_in_following(self, following):
+        """
+        :calls: `GET /users/:user/following/:target_user <http://developer.github.com/v3/users/followers/#check-if-one-user-follows-another>`_
+        :param following: :class:`github.NamedUser.NamedUser`
+        :rtype: bool
+        """
+        assert isinstance(following, github.NamedUser.NamedUser), following
+        status, headers, data = self._requester.requestJson(
+            "GET",
+            self.url + "/following/" + following._identity
+        )
+        return status == 204
+
+    @property
+    def _identity(self):
+        return self.login
+
+    def _initAttributes(self):
+        self._avatar_url = github.GithubObject.NotSet
+        self._bio = github.GithubObject.NotSet
+        self._blog = github.GithubObject.NotSet
+        self._collaborators = github.GithubObject.NotSet
+        self._company = github.GithubObject.NotSet
+        self._contributions = github.GithubObject.NotSet
+        self._created_at = github.GithubObject.NotSet
+        self._disk_usage = github.GithubObject.NotSet
+        self._email = github.GithubObject.NotSet
+        self._events_url = github.GithubObject.NotSet
+        self._followers = github.GithubObject.NotSet
+        self._followers_url = github.GithubObject.NotSet
+        self._following = github.GithubObject.NotSet
+        self._following_url = github.GithubObject.NotSet
+        self._gists_url = github.GithubObject.NotSet
+        self._gravatar_id = github.GithubObject.NotSet
+        self._hireable = github.GithubObject.NotSet
+        self._html_url = github.GithubObject.NotSet
+        self._id = github.GithubObject.NotSet
+        self._location = github.GithubObject.NotSet
+        self._login = github.GithubObject.NotSet
+        self._name = github.GithubObject.NotSet
+        self._organizations_url = github.GithubObject.NotSet
+        self._owned_private_repos = github.GithubObject.NotSet
+        self._plan = github.GithubObject.NotSet
+        self._private_gists = github.GithubObject.NotSet
+        self._public_gists = github.GithubObject.NotSet
+        self._public_repos = github.GithubObject.NotSet
+        self._received_events_url = github.GithubObject.NotSet
+        self._repos_url = github.GithubObject.NotSet
+        self._starred_url = github.GithubObject.NotSet
+        self._subscriptions_url = github.GithubObject.NotSet
+        self._total_private_repos = github.GithubObject.NotSet
+        self._type = github.GithubObject.NotSet
+        self._updated_at = github.GithubObject.NotSet
+        self._url = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "avatar_url" in attributes:  # pragma no branch
+            self._avatar_url = self._makeStringAttribute(attributes["avatar_url"])
+        if "bio" in attributes:  # pragma no branch
+            self._bio = self._makeStringAttribute(attributes["bio"])
+        if "blog" in attributes:  # pragma no branch
+            self._blog = self._makeStringAttribute(attributes["blog"])
+        if "collaborators" in attributes:  # pragma no branch
+            self._collaborators = self._makeIntAttribute(attributes["collaborators"])
+        if "company" in attributes:  # pragma no branch
+            self._company = self._makeStringAttribute(attributes["company"])
+        if "contributions" in attributes:  # pragma no branch
+            self._contributions = self._makeIntAttribute(attributes["contributions"])
+        if "created_at" in attributes:  # pragma no branch
+            self._created_at = self._makeDatetimeAttribute(attributes["created_at"])
+        if "disk_usage" in attributes:  # pragma no branch
+            self._disk_usage = self._makeIntAttribute(attributes["disk_usage"])
+        if "email" in attributes:  # pragma no branch
+            self._email = self._makeStringAttribute(attributes["email"])
+        if "events_url" in attributes:  # pragma no branch
+            self._events_url = self._makeStringAttribute(attributes["events_url"])
+        if "followers" in attributes:  # pragma no branch
+            self._followers = self._makeIntAttribute(attributes["followers"])
+        if "followers_url" in attributes:  # pragma no branch
+            self._followers_url = self._makeStringAttribute(attributes["followers_url"])
+        if "following" in attributes:  # pragma no branch
+            self._following = self._makeIntAttribute(attributes["following"])
+        if "following_url" in attributes:  # pragma no branch
+            self._following_url = self._makeStringAttribute(attributes["following_url"])
+        if "gists_url" in attributes:  # pragma no branch
+            self._gists_url = self._makeStringAttribute(attributes["gists_url"])
+        if "gravatar_id" in attributes:  # pragma no branch
+            self._gravatar_id = self._makeStringAttribute(attributes["gravatar_id"])
+        if "hireable" in attributes:  # pragma no branch
+            self._hireable = self._makeBoolAttribute(attributes["hireable"])
+        if "html_url" in attributes:  # pragma no branch
+            self._html_url = self._makeStringAttribute(attributes["html_url"])
+        if "id" in attributes:  # pragma no branch
+            self._id = self._makeIntAttribute(attributes["id"])
+        if "location" in attributes:  # pragma no branch
+            self._location = self._makeStringAttribute(attributes["location"])
+        if "login" in attributes:  # pragma no branch
+            self._login = self._makeStringAttribute(attributes["login"])
+        if "name" in attributes:  # pragma no branch
+            self._name = self._makeStringAttribute(attributes["name"])
+        if "organizations_url" in attributes:  # pragma no branch
+            self._organizations_url = self._makeStringAttribute(attributes["organizations_url"])
+        if "owned_private_repos" in attributes:  # pragma no branch
+            self._owned_private_repos = self._makeIntAttribute(attributes["owned_private_repos"])
+        if "plan" in attributes:  # pragma no branch
+            self._plan = self._makeClassAttribute(github.Plan.Plan, attributes["plan"])
+        if "private_gists" in attributes:  # pragma no branch
+            self._private_gists = self._makeIntAttribute(attributes["private_gists"])
+        if "public_gists" in attributes:  # pragma no branch
+            self._public_gists = self._makeIntAttribute(attributes["public_gists"])
+        if "public_repos" in attributes:  # pragma no branch
+            self._public_repos = self._makeIntAttribute(attributes["public_repos"])
+        if "received_events_url" in attributes:  # pragma no branch
+            self._received_events_url = self._makeStringAttribute(attributes["received_events_url"])
+        if "repos_url" in attributes:  # pragma no branch
+            self._repos_url = self._makeStringAttribute(attributes["repos_url"])
+        if "starred_url" in attributes:  # pragma no branch
+            self._starred_url = self._makeStringAttribute(attributes["starred_url"])
+        if "subscriptions_url" in attributes:  # pragma no branch
+            self._subscriptions_url = self._makeStringAttribute(attributes["subscriptions_url"])
+        if "total_private_repos" in attributes:  # pragma no branch
+            self._total_private_repos = self._makeIntAttribute(attributes["total_private_repos"])
+        if "type" in attributes:  # pragma no branch
+            self._type = self._makeStringAttribute(attributes["type"])
+        if "updated_at" in attributes:  # pragma no branch
+            self._updated_at = self._makeDatetimeAttribute(attributes["updated_at"])
+        if "url" in attributes:  # pragma no branch
+            self._url = self._makeStringAttribute(attributes["url"])

--- a/github/Notification.py
+++ b/github/Notification.py
@@ -1,0 +1,138 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Peter Golm <golm.peter@gmail.com>                             #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2013 martinqt <m.ki2@laposte.net>                                  #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+
+import github.Repository
+import github.NotificationSubject
+
+
+class Notification(github.GithubObject.CompletableGithubObject):
+    """
+    This class represents Notifications. The reference can be found here http://developer.github.com/v3/activity/notifications/
+    """
+
+    @property
+    def id(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._id)
+        return self._id.value
+
+    @property
+    def last_read_at(self):
+        """
+        :type: datetime.datetime
+        """
+        self._completeIfNotSet(self._last_read_at)
+        return self._last_read_at.value
+
+    @property
+    def repository(self):
+        """
+        :type: :class:`github.Repository.Repository`
+        """
+        self._completeIfNotSet(self._repository)
+        return self._repository.value
+
+    @property
+    def subject(self):
+        """
+        :type: :class:`github.NotificationSubject.NotificationSubject`
+        """
+        self._completeIfNotSet(self._subject)
+        return self._subject.value
+
+    @property
+    def reason(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._reason)
+        return self._reason.value
+
+    @property
+    def subscription_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._subscription_url)
+        return self._subscription_url.value
+
+    @property
+    def unread(self):
+        """
+        :type: bool
+        """
+        self._completeIfNotSet(self._unread)
+        return self._unread.value
+
+    @property
+    def updated_at(self):
+        """
+        :type: datetime.datetime
+        """
+        self._completeIfNotSet(self._updated_at)
+        return self._updated_at.value
+
+    @property
+    def url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._url)
+        return self._url.value
+
+    def _initAttributes(self):
+        self._id = github.GithubObject.NotSet
+        self._last_read_at = github.GithubObject.NotSet
+        self._repository = github.GithubObject.NotSet
+        self._reason = github.GithubObject.NotSet
+        self._subscription_url = github.GithubObject.NotSet
+        self._unread = github.GithubObject.NotSet
+        self._updated_at = github.GithubObject.NotSet
+        self._url = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "id" in attributes:  # pragma no branch
+            self._id = self._makeStringAttribute(attributes["id"])
+        if "last_read_at" in attributes:  # pragma no branch
+            self._last_read_at = self._makeDatetimeAttribute(attributes["last_read_at"])
+        if "repository" in attributes:  # pragma no branch
+            self._repository = self._makeClassAttribute(github.Repository.Repository, attributes["repository"])
+        if "subject" in attributes:  # pragma no branch
+            self._subject = self._makeClassAttribute(github.NotificationSubject.NotificationSubject, attributes["subject"])
+        if "reason" in attributes:  # pragma no branch
+            self._reason = self._makeStringAttribute(attributes["reason"])
+        if "subscription_url" in attributes:  # pragma no branch
+            self._subscription_url = self._makeStringAttribute(attributes["subscription_url"])
+        if "unread" in attributes:  # pragma no branch
+            self._unread = self._makeBoolAttribute(attributes["unread"])
+        if "updated_at" in attributes:  # pragma no branch
+            self._updated_at = self._makeDatetimeAttribute(attributes["updated_at"])
+        if "url" in attributes:  # pragma no branch
+            self._url = self._makeStringAttribute(attributes["url"])

--- a/github/NotificationSubject.py
+++ b/github/NotificationSubject.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+
+
+class NotificationSubject(github.GithubObject.NonCompletableGithubObject):
+    """
+    This class represents Subjects of Notifications as returned for example by http://developer.github.com/v3/activity/notifications/#list-your-notifications
+    """
+
+    @property
+    def title(self):
+        """
+        :type: string
+        """
+        return self._title.value
+
+    @property
+    def url(self):
+        """
+        :type: string
+        """
+        return self._url.value
+
+    @property
+    def latest_comment_url(self):
+        """
+        :type: string
+        """
+        return self._latest_comment_url.value
+
+    @property
+    def type(self):
+        """
+        :type: string
+        """
+        return self._type.value
+
+    def _initAttributes(self):
+        self._title = github.GithubObject.NotSet
+        self._url = github.GithubObject.NotSet
+        self._latest_comment_url = github.GithubObject.NotSet
+        self._type = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "title" in attributes:  # pragma no branch
+            self._title = self._makeStringAttribute(attributes["title"])
+        if "url" in attributes:  # pragma no branch
+            self._url = self._makeStringAttribute(attributes["url"])
+        if "latest_comment_url" in attributes:  # pragma no branch
+            self._latest_comment_url = self._makeStringAttribute(attributes["latest_comment_url"])
+        if "type" in attributes:  # pragma no branch
+            self._type = self._makeStringAttribute(attributes["type"])

--- a/github/Organization.py
+++ b/github/Organization.py
@@ -1,0 +1,703 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Steve English <steve.english@navetas.com>                     #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2013 martinqt <m.ki2@laposte.net>                                  #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import datetime
+
+import github.GithubObject
+import github.PaginatedList
+
+import github.Plan
+import github.Team
+import github.Event
+import github.Repository
+import github.NamedUser
+
+
+class Organization(github.GithubObject.CompletableGithubObject):
+    """
+    This class represents Organizations. The reference can be found here http://developer.github.com/v3/orgs/
+    """
+
+    @property
+    def avatar_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._avatar_url)
+        return self._avatar_url.value
+
+    @property
+    def billing_email(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._billing_email)
+        return self._billing_email.value
+
+    @property
+    def blog(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._blog)
+        return self._blog.value
+
+    @property
+    def collaborators(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._collaborators)
+        return self._collaborators.value
+
+    @property
+    def company(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._company)
+        return self._company.value
+
+    @property
+    def created_at(self):
+        """
+        :type: datetime.datetime
+        """
+        self._completeIfNotSet(self._created_at)
+        return self._created_at.value
+
+    @property
+    def disk_usage(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._disk_usage)
+        return self._disk_usage.value
+
+    @property
+    def email(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._email)
+        return self._email.value
+
+    @property
+    def events_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._events_url)
+        return self._events_url.value
+
+    @property
+    def followers(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._followers)
+        return self._followers.value
+
+    @property
+    def following(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._following)
+        return self._following.value
+
+    @property
+    def gravatar_id(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._gravatar_id)
+        return self._gravatar_id.value
+
+    @property
+    def html_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._html_url)
+        return self._html_url.value
+
+    @property
+    def id(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._id)
+        return self._id.value
+
+    @property
+    def location(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._location)
+        return self._location.value
+
+    @property
+    def login(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._login)
+        return self._login.value
+
+    @property
+    def members_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._members_url)
+        return self._members_url.value
+
+    @property
+    def name(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._name)
+        return self._name.value
+
+    @property
+    def owned_private_repos(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._owned_private_repos)
+        return self._owned_private_repos.value
+
+    @property
+    def plan(self):
+        """
+        :type: :class:`github.Plan.Plan`
+        """
+        self._completeIfNotSet(self._plan)
+        return self._plan.value
+
+    @property
+    def private_gists(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._private_gists)
+        return self._private_gists.value
+
+    @property
+    def public_gists(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._public_gists)
+        return self._public_gists.value
+
+    @property
+    def public_members_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._public_members_url)
+        return self._public_members_url.value
+
+    @property
+    def public_repos(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._public_repos)
+        return self._public_repos.value
+
+    @property
+    def repos_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._repos_url)
+        return self._repos_url.value
+
+    @property
+    def total_private_repos(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._total_private_repos)
+        return self._total_private_repos.value
+
+    @property
+    def type(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._type)
+        return self._type.value
+
+    @property
+    def updated_at(self):
+        """
+        :type: datetime.datetime
+        """
+        self._completeIfNotSet(self._updated_at)
+        return self._updated_at.value
+
+    @property
+    def url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._url)
+        return self._url.value
+
+    def add_to_public_members(self, public_member):
+        """
+        :calls: `PUT /orgs/:org/public_members/:user <http://developer.github.com/v3/orgs/members>`_
+        :param public_member: :class:`github.NamedUser.NamedUser`
+        :rtype: None
+        """
+        assert isinstance(public_member, github.NamedUser.NamedUser), public_member
+        headers, data = self._requester.requestJsonAndCheck(
+            "PUT",
+            self.url + "/public_members/" + public_member._identity
+        )
+
+    def create_fork(self, repo):
+        """
+        :calls: `POST /repos/:owner/:repo/forks <http://developer.github.com/v3/repos/forks>`_
+        :param repo: :class:`github.Repository.Repository`
+        :rtype: :class:`github.Repository.Repository`
+        """
+        assert isinstance(repo, github.Repository.Repository), repo
+        url_parameters = {
+            "org": self.login,
+        }
+        headers, data = self._requester.requestJsonAndCheck(
+            "POST",
+            "/repos/" + repo.owner.login + "/" + repo.name + "/forks",
+            parameters=url_parameters
+        )
+        return github.Repository.Repository(self._requester, headers, data, completed=True)
+
+    def create_repo(self, name, description=github.GithubObject.NotSet, homepage=github.GithubObject.NotSet, private=github.GithubObject.NotSet, has_issues=github.GithubObject.NotSet, has_wiki=github.GithubObject.NotSet, has_downloads=github.GithubObject.NotSet, team_id=github.GithubObject.NotSet, auto_init=github.GithubObject.NotSet, gitignore_template=github.GithubObject.NotSet):
+        """
+        :calls: `POST /orgs/:org/repos <http://developer.github.com/v3/repos>`_
+        :param name: string
+        :param description: string
+        :param homepage: string
+        :param private: bool
+        :param has_issues: bool
+        :param has_wiki: bool
+        :param has_downloads: bool
+        :param team_id: :class:`github.Team.Team`
+        :param auto_init: bool
+        :param gitignore_template: string
+        :rtype: :class:`github.Repository.Repository`
+        """
+        assert isinstance(name, (str, unicode)), name
+        assert description is github.GithubObject.NotSet or isinstance(description, (str, unicode)), description
+        assert homepage is github.GithubObject.NotSet or isinstance(homepage, (str, unicode)), homepage
+        assert private is github.GithubObject.NotSet or isinstance(private, bool), private
+        assert has_issues is github.GithubObject.NotSet or isinstance(has_issues, bool), has_issues
+        assert has_wiki is github.GithubObject.NotSet or isinstance(has_wiki, bool), has_wiki
+        assert has_downloads is github.GithubObject.NotSet or isinstance(has_downloads, bool), has_downloads
+        assert team_id is github.GithubObject.NotSet or isinstance(team_id, github.Team.Team), team_id
+        assert auto_init is github.GithubObject.NotSet or isinstance(auto_init, bool), auto_init
+        assert gitignore_template is github.GithubObject.NotSet or isinstance(gitignore_template, (str, unicode)), gitignore_template
+        post_parameters = {
+            "name": name,
+        }
+        if description is not github.GithubObject.NotSet:
+            post_parameters["description"] = description
+        if homepage is not github.GithubObject.NotSet:
+            post_parameters["homepage"] = homepage
+        if private is not github.GithubObject.NotSet:
+            post_parameters["private"] = private
+        if has_issues is not github.GithubObject.NotSet:
+            post_parameters["has_issues"] = has_issues
+        if has_wiki is not github.GithubObject.NotSet:
+            post_parameters["has_wiki"] = has_wiki
+        if has_downloads is not github.GithubObject.NotSet:
+            post_parameters["has_downloads"] = has_downloads
+        if team_id is not github.GithubObject.NotSet:
+            post_parameters["team_id"] = team_id._identity
+        if auto_init is not github.GithubObject.NotSet:
+            post_parameters["auto_init"] = auto_init
+        if gitignore_template is not github.GithubObject.NotSet:
+            post_parameters["gitignore_template"] = gitignore_template
+        headers, data = self._requester.requestJsonAndCheck(
+            "POST",
+            self.url + "/repos",
+            input=post_parameters
+        )
+        return github.Repository.Repository(self._requester, headers, data, completed=True)
+
+    def create_team(self, name, repo_names=github.GithubObject.NotSet, permission=github.GithubObject.NotSet):
+        """
+        :calls: `POST /orgs/:org/teams <http://developer.github.com/v3/orgs/teams>`_
+        :param name: string
+        :param repo_names: list of :class:`github.Repository.Repository`
+        :param permission: string
+        :rtype: :class:`github.Team.Team`
+        """
+        assert isinstance(name, (str, unicode)), name
+        assert repo_names is github.GithubObject.NotSet or all(isinstance(element, github.Repository.Repository) for element in repo_names), repo_names
+        assert permission is github.GithubObject.NotSet or isinstance(permission, (str, unicode)), permission
+        post_parameters = {
+            "name": name,
+        }
+        if repo_names is not github.GithubObject.NotSet:
+            post_parameters["repo_names"] = [element._identity for element in repo_names]
+        if permission is not github.GithubObject.NotSet:
+            post_parameters["permission"] = permission
+        headers, data = self._requester.requestJsonAndCheck(
+            "POST",
+            self.url + "/teams",
+            input=post_parameters
+        )
+        return github.Team.Team(self._requester, headers, data, completed=True)
+
+    def edit(self, billing_email=github.GithubObject.NotSet, blog=github.GithubObject.NotSet, company=github.GithubObject.NotSet, email=github.GithubObject.NotSet, location=github.GithubObject.NotSet, name=github.GithubObject.NotSet):
+        """
+        :calls: `PATCH /orgs/:org <http://developer.github.com/v3/orgs>`_
+        :param billing_email: string
+        :param blog: string
+        :param company: string
+        :param email: string
+        :param location: string
+        :param name: string
+        :rtype: None
+        """
+        assert billing_email is github.GithubObject.NotSet or isinstance(billing_email, (str, unicode)), billing_email
+        assert blog is github.GithubObject.NotSet or isinstance(blog, (str, unicode)), blog
+        assert company is github.GithubObject.NotSet or isinstance(company, (str, unicode)), company
+        assert email is github.GithubObject.NotSet or isinstance(email, (str, unicode)), email
+        assert location is github.GithubObject.NotSet or isinstance(location, (str, unicode)), location
+        assert name is github.GithubObject.NotSet or isinstance(name, (str, unicode)), name
+        post_parameters = dict()
+        if billing_email is not github.GithubObject.NotSet:
+            post_parameters["billing_email"] = billing_email
+        if blog is not github.GithubObject.NotSet:
+            post_parameters["blog"] = blog
+        if company is not github.GithubObject.NotSet:
+            post_parameters["company"] = company
+        if email is not github.GithubObject.NotSet:
+            post_parameters["email"] = email
+        if location is not github.GithubObject.NotSet:
+            post_parameters["location"] = location
+        if name is not github.GithubObject.NotSet:
+            post_parameters["name"] = name
+        headers, data = self._requester.requestJsonAndCheck(
+            "PATCH",
+            self.url,
+            input=post_parameters
+        )
+        self._useAttributes(data)
+
+    def get_events(self):
+        """
+        :calls: `GET /orgs/:org/events <http://developer.github.com/v3/activity/events>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Event.Event`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.Event.Event,
+            self._requester,
+            self.url + "/events",
+            None
+        )
+
+    def get_issues(self, filter=github.GithubObject.NotSet, state=github.GithubObject.NotSet, labels=github.GithubObject.NotSet, sort=github.GithubObject.NotSet, direction=github.GithubObject.NotSet, since=github.GithubObject.NotSet):
+        """
+        :calls: `GET /orgs/:org/issues <http://developer.github.com/v3/issues>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Issue.Issue`
+        :param filter: string
+        :param state: string
+        :param labels: list of :class:`github.Label.Label`
+        :param sort: string
+        :param direction: string
+        :param since: datetime.datetime
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Issue.Issue`
+        """
+        assert filter is github.GithubObject.NotSet or isinstance(filter, (str, unicode)), filter
+        assert state is github.GithubObject.NotSet or isinstance(state, (str, unicode)), state
+        assert labels is github.GithubObject.NotSet or all(isinstance(element, github.Label.Label) for element in labels), labels
+        assert sort is github.GithubObject.NotSet or isinstance(sort, (str, unicode)), sort
+        assert direction is github.GithubObject.NotSet or isinstance(direction, (str, unicode)), direction
+        assert since is github.GithubObject.NotSet or isinstance(since, datetime.datetime), since
+        url_parameters = dict()
+        if filter is not github.GithubObject.NotSet:
+            url_parameters["filter"] = filter
+        if state is not github.GithubObject.NotSet:
+            url_parameters["state"] = state
+        if labels is not github.GithubObject.NotSet:
+            url_parameters["labels"] = ",".join(label.name for label in labels)
+        if sort is not github.GithubObject.NotSet:
+            url_parameters["sort"] = sort
+        if direction is not github.GithubObject.NotSet:
+            url_parameters["direction"] = direction
+        if since is not github.GithubObject.NotSet:
+            url_parameters["since"] = since.strftime("%Y-%m-%dT%H:%M:%SZ")
+        return github.PaginatedList.PaginatedList(
+            github.Issue.Issue,
+            self._requester,
+            self.url + "/issues",
+            url_parameters
+        )
+
+    def get_members(self, filter_=github.GithubObject.NotSet,
+                    role=github.GithubObject.NotSet):
+        """
+        :calls: `GET /orgs/:org/members <http://developer.github.com/v3/orgs/members>`_
+        :param filter_: string
+        :param role: string
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.NamedUser.NamedUser`
+        """
+        assert (filter_ is github.GithubObject.NotSet or
+                isinstance(filter_, (str, unicode))), filter_
+        assert (role is github.GithubObject.NotSet or
+                isinstance(role, (str, unicode))), role
+
+        url_parameters = {}
+        if filter_ is not github.GithubObject.NotSet:
+            url_parameters["filter"] = filter_
+        if role is not github.GithubObject.NotSet:
+            url_parameters["role"] = role
+        return github.PaginatedList.PaginatedList(
+            github.NamedUser.NamedUser,
+            self._requester,
+            self.url + "/members",
+            url_parameters
+        )
+
+    def get_public_members(self):
+        """
+        :calls: `GET /orgs/:org/public_members <http://developer.github.com/v3/orgs/members>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.NamedUser.NamedUser`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.NamedUser.NamedUser,
+            self._requester,
+            self.url + "/public_members",
+            None
+        )
+
+    def get_repo(self, name):
+        """
+        :calls: `GET /repos/:owner/:repo <http://developer.github.com/v3/repos>`_
+        :param name: string
+        :rtype: :class:`github.Repository.Repository`
+        """
+        assert isinstance(name, (str, unicode)), name
+        headers, data = self._requester.requestJsonAndCheck(
+            "GET",
+            "/repos/" + self.login + "/" + name
+        )
+        return github.Repository.Repository(self._requester, headers, data, completed=True)
+
+    def get_repos(self, type=github.GithubObject.NotSet):
+        """
+        :calls: `GET /orgs/:org/repos <http://developer.github.com/v3/repos>`_
+        :param type: string
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Repository.Repository`
+        """
+        assert type is github.GithubObject.NotSet or isinstance(type, (str, unicode)), type
+        url_parameters = dict()
+        if type is not github.GithubObject.NotSet:
+            url_parameters["type"] = type
+        return github.PaginatedList.PaginatedList(
+            github.Repository.Repository,
+            self._requester,
+            self.url + "/repos",
+            url_parameters
+        )
+
+    def get_team(self, id):
+        """
+        :calls: `GET /teams/:id <http://developer.github.com/v3/orgs/teams>`_
+        :param id: integer
+        :rtype: :class:`github.Team.Team`
+        """
+        assert isinstance(id, (int, long)), id
+        headers, data = self._requester.requestJsonAndCheck(
+            "GET",
+            "/teams/" + str(id)
+        )
+        return github.Team.Team(self._requester, headers, data, completed=True)
+
+    def get_teams(self):
+        """
+        :calls: `GET /orgs/:org/teams <http://developer.github.com/v3/orgs/teams>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Team.Team`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.Team.Team,
+            self._requester,
+            self.url + "/teams",
+            None
+        )
+
+    def has_in_members(self, member):
+        """
+        :calls: `GET /orgs/:org/members/:user <http://developer.github.com/v3/orgs/members>`_
+        :param member: :class:`github.NamedUser.NamedUser`
+        :rtype: bool
+        """
+        assert isinstance(member, github.NamedUser.NamedUser), member
+        status, headers, data = self._requester.requestJson(
+            "GET",
+            self.url + "/members/" + member._identity
+        )
+        return status == 204
+
+    def has_in_public_members(self, public_member):
+        """
+        :calls: `GET /orgs/:org/public_members/:user <http://developer.github.com/v3/orgs/members>`_
+        :param public_member: :class:`github.NamedUser.NamedUser`
+        :rtype: bool
+        """
+        assert isinstance(public_member, github.NamedUser.NamedUser), public_member
+        status, headers, data = self._requester.requestJson(
+            "GET",
+            self.url + "/public_members/" + public_member._identity
+        )
+        return status == 204
+
+    def remove_from_members(self, member):
+        """
+        :calls: `DELETE /orgs/:org/members/:user <http://developer.github.com/v3/orgs/members>`_
+        :param member: :class:`github.NamedUser.NamedUser`
+        :rtype: None
+        """
+        assert isinstance(member, github.NamedUser.NamedUser), member
+        headers, data = self._requester.requestJsonAndCheck(
+            "DELETE",
+            self.url + "/members/" + member._identity
+        )
+
+    def remove_from_public_members(self, public_member):
+        """
+        :calls: `DELETE /orgs/:org/public_members/:user <http://developer.github.com/v3/orgs/members>`_
+        :param public_member: :class:`github.NamedUser.NamedUser`
+        :rtype: None
+        """
+        assert isinstance(public_member, github.NamedUser.NamedUser), public_member
+        headers, data = self._requester.requestJsonAndCheck(
+            "DELETE",
+            self.url + "/public_members/" + public_member._identity
+        )
+
+    def _initAttributes(self):
+        self._avatar_url = github.GithubObject.NotSet
+        self._billing_email = github.GithubObject.NotSet
+        self._blog = github.GithubObject.NotSet
+        self._collaborators = github.GithubObject.NotSet
+        self._company = github.GithubObject.NotSet
+        self._created_at = github.GithubObject.NotSet
+        self._disk_usage = github.GithubObject.NotSet
+        self._email = github.GithubObject.NotSet
+        self._events_url = github.GithubObject.NotSet
+        self._followers = github.GithubObject.NotSet
+        self._following = github.GithubObject.NotSet
+        self._gravatar_id = github.GithubObject.NotSet
+        self._html_url = github.GithubObject.NotSet
+        self._id = github.GithubObject.NotSet
+        self._location = github.GithubObject.NotSet
+        self._login = github.GithubObject.NotSet
+        self._members_url = github.GithubObject.NotSet
+        self._name = github.GithubObject.NotSet
+        self._owned_private_repos = github.GithubObject.NotSet
+        self._plan = github.GithubObject.NotSet
+        self._private_gists = github.GithubObject.NotSet
+        self._public_gists = github.GithubObject.NotSet
+        self._public_members_url = github.GithubObject.NotSet
+        self._public_repos = github.GithubObject.NotSet
+        self._repos_url = github.GithubObject.NotSet
+        self._total_private_repos = github.GithubObject.NotSet
+        self._type = github.GithubObject.NotSet
+        self._updated_at = github.GithubObject.NotSet
+        self._url = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "avatar_url" in attributes:  # pragma no branch
+            self._avatar_url = self._makeStringAttribute(attributes["avatar_url"])
+        if "billing_email" in attributes:  # pragma no branch
+            self._billing_email = self._makeStringAttribute(attributes["billing_email"])
+        if "blog" in attributes:  # pragma no branch
+            self._blog = self._makeStringAttribute(attributes["blog"])
+        if "collaborators" in attributes:  # pragma no branch
+            self._collaborators = self._makeIntAttribute(attributes["collaborators"])
+        if "company" in attributes:  # pragma no branch
+            self._company = self._makeStringAttribute(attributes["company"])
+        if "created_at" in attributes:  # pragma no branch
+            self._created_at = self._makeDatetimeAttribute(attributes["created_at"])
+        if "disk_usage" in attributes:  # pragma no branch
+            self._disk_usage = self._makeIntAttribute(attributes["disk_usage"])
+        if "email" in attributes:  # pragma no branch
+            self._email = self._makeStringAttribute(attributes["email"])
+        if "events_url" in attributes:  # pragma no branch
+            self._events_url = self._makeStringAttribute(attributes["events_url"])
+        if "followers" in attributes:  # pragma no branch
+            self._followers = self._makeIntAttribute(attributes["followers"])
+        if "following" in attributes:  # pragma no branch
+            self._following = self._makeIntAttribute(attributes["following"])
+        if "gravatar_id" in attributes:  # pragma no branch
+            self._gravatar_id = self._makeStringAttribute(attributes["gravatar_id"])
+        if "html_url" in attributes:  # pragma no branch
+            self._html_url = self._makeStringAttribute(attributes["html_url"])
+        if "id" in attributes:  # pragma no branch
+            self._id = self._makeIntAttribute(attributes["id"])
+        if "location" in attributes:  # pragma no branch
+            self._location = self._makeStringAttribute(attributes["location"])
+        if "login" in attributes:  # pragma no branch
+            self._login = self._makeStringAttribute(attributes["login"])
+        if "members_url" in attributes:  # pragma no branch
+            self._members_url = self._makeStringAttribute(attributes["members_url"])
+        if "name" in attributes:  # pragma no branch
+            self._name = self._makeStringAttribute(attributes["name"])
+        if "owned_private_repos" in attributes:  # pragma no branch
+            self._owned_private_repos = self._makeIntAttribute(attributes["owned_private_repos"])
+        if "plan" in attributes:  # pragma no branch
+            self._plan = self._makeClassAttribute(github.Plan.Plan, attributes["plan"])
+        if "private_gists" in attributes:  # pragma no branch
+            self._private_gists = self._makeIntAttribute(attributes["private_gists"])
+        if "public_gists" in attributes:  # pragma no branch
+            self._public_gists = self._makeIntAttribute(attributes["public_gists"])
+        if "public_members_url" in attributes:  # pragma no branch
+            self._public_members_url = self._makeStringAttribute(attributes["public_members_url"])
+        if "public_repos" in attributes:  # pragma no branch
+            self._public_repos = self._makeIntAttribute(attributes["public_repos"])
+        if "repos_url" in attributes:  # pragma no branch
+            self._repos_url = self._makeStringAttribute(attributes["repos_url"])
+        if "total_private_repos" in attributes:  # pragma no branch
+            self._total_private_repos = self._makeIntAttribute(attributes["total_private_repos"])
+        if "type" in attributes:  # pragma no branch
+            self._type = self._makeStringAttribute(attributes["type"])
+        if "updated_at" in attributes:  # pragma no branch
+            self._updated_at = self._makeDatetimeAttribute(attributes["updated_at"])
+        if "url" in attributes:  # pragma no branch
+            self._url = self._makeStringAttribute(attributes["url"])

--- a/github/PaginatedList.py
+++ b/github/PaginatedList.py
@@ -1,0 +1,218 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Bill Mill <bill.mill@gmail.com>                               #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2013 davidbrai <davidbrai@gmail.com>                               #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+
+
+class PaginatedListBase:
+    def __init__(self):
+        self.__elements = list()
+
+    def __getitem__(self, index):
+        assert isinstance(index, (int, slice))
+        if isinstance(index, (int, long)):
+            self.__fetchToIndex(index)
+            return self.__elements[index]
+        else:
+            return self._Slice(self, index)
+
+    def __iter__(self):
+        for element in self.__elements:
+            yield element
+        while self._couldGrow():
+            newElements = self._grow()
+            for element in newElements:
+                yield element
+
+    def _isBiggerThan(self, index):
+        return len(self.__elements) > index or self._couldGrow()
+
+    def __fetchToIndex(self, index):
+        while len(self.__elements) <= index and self._couldGrow():
+            self._grow()
+
+    def _grow(self):
+        newElements = self._fetchNextPage()
+        self.__elements += newElements
+        return newElements
+
+    class _Slice:
+        def __init__(self, theList, theSlice):
+            self.__list = theList
+            self.__start = theSlice.start or 0
+            self.__stop = theSlice.stop
+            self.__step = theSlice.step or 1
+
+        def __iter__(self):
+            index = self.__start
+            while not self.__finished(index):
+                if self.__list._isBiggerThan(index):
+                    yield self.__list[index]
+                    index += self.__step
+                else:
+                    return
+
+        def __finished(self, index):
+            return self.__stop is not None and index >= self.__stop
+
+
+class PaginatedList(PaginatedListBase):
+    """
+    This class abstracts the `pagination of the API <http://developer.github.com/v3/#pagination>`_.
+
+    You can simply enumerate through instances of this class::
+
+        for repo in user.get_repos():
+            print repo.name
+
+    You can also index them or take slices::
+
+        second_repo = user.get_repos()[1]
+        first_repos = user.get_repos()[:10]
+
+    If you want to iterate in reversed order, just do::
+
+        for repo in user.get_repos().reversed:
+            print repo.name
+
+    And if you really need it, you can explicitely access a specific page::
+
+        some_repos = user.get_repos().get_page(0)
+        some_other_repos = user.get_repos().get_page(3)
+    """
+
+    def __init__(self, contentClass, requester, firstUrl, firstParams, headers=None):
+        PaginatedListBase.__init__(self)
+        self.__requester = requester
+        self.__contentClass = contentClass
+        self.__firstUrl = firstUrl
+        self.__firstParams = firstParams or ()
+        self.__nextUrl = firstUrl
+        self.__nextParams = firstParams or {}
+        self.__headers = headers
+        if self.__requester.per_page != 30:
+            self.__nextParams["per_page"] = self.__requester.per_page
+        self._reversed = False
+        self.__totalCount = None
+
+    @property
+    def totalCount(self):
+        if not self.__totalCount:
+            self._grow()
+
+        return self.__totalCount
+
+    def _getLastPageUrl(self):
+        headers, data = self.__requester.requestJsonAndCheck(
+            "GET",
+            self.__firstUrl,
+            parameters=self.__nextParams,
+            headers=self.__headers
+        )
+        links = self.__parseLinkHeader(headers)
+        lastUrl = links.get("last")
+        return lastUrl
+
+    @property
+    def reversed(self):
+        r = PaginatedList(self.__contentClass, self.__requester, self.__firstUrl, self.__firstParams)
+        r.__reverse()
+        return r
+
+    def __reverse(self):
+        self._reversed = True
+        lastUrl = self._getLastPageUrl()
+        if lastUrl:
+            self.__nextUrl = lastUrl
+
+    def _couldGrow(self):
+        return self.__nextUrl is not None
+
+    def _fetchNextPage(self):
+        headers, data = self.__requester.requestJsonAndCheck(
+            "GET",
+            self.__nextUrl,
+            parameters=self.__nextParams,
+            headers=self.__headers
+        )
+        data = data if data else []
+
+        self.__nextUrl = None
+        if len(data) > 0:
+            links = self.__parseLinkHeader(headers)
+            if self._reversed:
+                if "prev" in links:
+                    self.__nextUrl = links["prev"]
+            elif "next" in links:
+                self.__nextUrl = links["next"]
+        self.__nextParams = None
+
+        if 'items' in data:
+            self.__totalCount = data['total_count']
+            data = data["items"]
+
+        content = [
+            self.__contentClass(self.__requester, headers, element, completed=False)
+            for element in data if element is not None
+        ]
+        if self._reversed:
+            return content[::-1]
+        return content
+
+    def __parseLinkHeader(self, headers):
+        links = {}
+        if "link" in headers:
+            linkHeaders = headers["link"].split(", ")
+            for linkHeader in linkHeaders:
+                (url, rel) = linkHeader.split("; ")
+                url = url[1:-1]
+                rel = rel[5:-1]
+                links[rel] = url
+        return links
+
+    def get_page(self, page):
+        params = dict(self.__firstParams)
+        if page != 0:
+            params["page"] = page + 1
+        if self.__requester.per_page != 30:
+            params["per_page"] = self.__requester.per_page
+        headers, data = self.__requester.requestJsonAndCheck(
+            "GET",
+            self.__firstUrl,
+            parameters=params,
+            headers=self.__headers
+        )
+
+        if 'items' in data:
+            self.__totalCount = data['total_count']
+            data = data["items"]
+
+        return [
+            self.__contentClass(self.__requester, headers, element, completed=False)
+            for element in data
+        ]

--- a/github/Permissions.py
+++ b/github/Permissions.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+
+
+class Permissions(github.GithubObject.NonCompletableGithubObject):
+    """
+    This class represents Permissionss as returned for example by http://developer.github.com/v3/todo
+    """
+
+    @property
+    def admin(self):
+        """
+        :type: bool
+        """
+        return self._admin.value
+
+    @property
+    def pull(self):
+        """
+        :type: bool
+        """
+        return self._pull.value
+
+    @property
+    def push(self):
+        """
+        :type: bool
+        """
+        return self._push.value
+
+    def _initAttributes(self):
+        self._admin = github.GithubObject.NotSet
+        self._pull = github.GithubObject.NotSet
+        self._push = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "admin" in attributes:  # pragma no branch
+            self._admin = self._makeBoolAttribute(attributes["admin"])
+        if "pull" in attributes:  # pragma no branch
+            self._pull = self._makeBoolAttribute(attributes["pull"])
+        if "push" in attributes:  # pragma no branch
+            self._push = self._makeBoolAttribute(attributes["push"])

--- a/github/Plan.py
+++ b/github/Plan.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+
+
+class Plan(github.GithubObject.NonCompletableGithubObject):
+    """
+    This class represents Plans as returned for example by http://developer.github.com/v3/todo
+    """
+
+    @property
+    def collaborators(self):
+        """
+        :type: integer
+        """
+        return self._collaborators.value
+
+    @property
+    def name(self):
+        """
+        :type: string
+        """
+        return self._name.value
+
+    @property
+    def private_repos(self):
+        """
+        :type: integer
+        """
+        return self._private_repos.value
+
+    @property
+    def space(self):
+        """
+        :type: integer
+        """
+        return self._space.value
+
+    def _initAttributes(self):
+        self._collaborators = github.GithubObject.NotSet
+        self._name = github.GithubObject.NotSet
+        self._private_repos = github.GithubObject.NotSet
+        self._space = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "collaborators" in attributes:  # pragma no branch
+            self._collaborators = self._makeIntAttribute(attributes["collaborators"])
+        if "name" in attributes:  # pragma no branch
+            self._name = self._makeStringAttribute(attributes["name"])
+        if "private_repos" in attributes:  # pragma no branch
+            self._private_repos = self._makeIntAttribute(attributes["private_repos"])
+        if "space" in attributes:  # pragma no branch
+            self._space = self._makeIntAttribute(attributes["space"])

--- a/github/PullRequest.py
+++ b/github/PullRequest.py
@@ -1,0 +1,618 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Michael Stead <michael.stead@gmail.com>                       #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2013 martinqt <m.ki2@laposte.net>                                  #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+import github.PaginatedList
+
+import github.PullRequestMergeStatus
+import github.NamedUser
+import github.PullRequestPart
+import github.PullRequestComment
+import github.File
+import github.IssueComment
+import github.Commit
+
+
+class PullRequest(github.GithubObject.CompletableGithubObject):
+    """
+    This class represents PullRequests. The reference can be found here http://developer.github.com/v3/pulls/
+    """
+
+    @property
+    def additions(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._additions)
+        return self._additions.value
+
+    @property
+    def assignee(self):
+        """
+        :type: :class:`github.NamedUser.NamedUser`
+        """
+        self._completeIfNotSet(self._assignee)
+        return self._assignee.value
+
+    @property
+    def base(self):
+        """
+        :type: :class:`github.PullRequestPart.PullRequestPart`
+        """
+        self._completeIfNotSet(self._base)
+        return self._base.value
+
+    @property
+    def body(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._body)
+        return self._body.value
+
+    @property
+    def changed_files(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._changed_files)
+        return self._changed_files.value
+
+    @property
+    def closed_at(self):
+        """
+        :type: datetime.datetime
+        """
+        self._completeIfNotSet(self._closed_at)
+        return self._closed_at.value
+
+    @property
+    def comments(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._comments)
+        return self._comments.value
+
+    @property
+    def comments_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._comments_url)
+        return self._comments_url.value
+
+    @property
+    def commits(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._commits)
+        return self._commits.value
+
+    @property
+    def commits_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._commits_url)
+        return self._commits_url.value
+
+    @property
+    def created_at(self):
+        """
+        :type: datetime.datetime
+        """
+        self._completeIfNotSet(self._created_at)
+        return self._created_at.value
+
+    @property
+    def deletions(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._deletions)
+        return self._deletions.value
+
+    @property
+    def diff_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._diff_url)
+        return self._diff_url.value
+
+    @property
+    def head(self):
+        """
+        :type: :class:`github.PullRequestPart.PullRequestPart`
+        """
+        self._completeIfNotSet(self._head)
+        return self._head.value
+
+    @property
+    def html_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._html_url)
+        return self._html_url.value
+
+    @property
+    def id(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._id)
+        return self._id.value
+
+    @property
+    def issue_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._issue_url)
+        return self._issue_url.value
+
+    @property
+    def merge_commit_sha(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._merge_commit_sha)
+        return self._merge_commit_sha.value
+
+    @property
+    def mergeable(self):
+        """
+        :type: bool
+        """
+        self._completeIfNotSet(self._mergeable)
+        return self._mergeable.value
+
+    @property
+    def mergeable_state(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._mergeable_state)
+        return self._mergeable_state.value
+
+    @property
+    def merged(self):
+        """
+        :type: bool
+        """
+        self._completeIfNotSet(self._merged)
+        return self._merged.value
+
+    @property
+    def merged_at(self):
+        """
+        :type: datetime.datetime
+        """
+        self._completeIfNotSet(self._merged_at)
+        return self._merged_at.value
+
+    @property
+    def merged_by(self):
+        """
+        :type: :class:`github.NamedUser.NamedUser`
+        """
+        self._completeIfNotSet(self._merged_by)
+        return self._merged_by.value
+
+    @property
+    def milestone(self):
+        """
+        :type: :class:`github.Milestone.Milestone`
+        """
+        self._completeIfNotSet(self._milestone)
+        return self._milestone.value
+
+    @property
+    def number(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._number)
+        return self._number.value
+
+    @property
+    def patch_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._patch_url)
+        return self._patch_url.value
+
+    @property
+    def review_comment_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._review_comment_url)
+        return self._review_comment_url.value
+
+    @property
+    def review_comments(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._review_comments)
+        return self._review_comments.value
+
+    @property
+    def review_comments_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._review_comments_url)
+        return self._review_comments_url.value
+
+    @property
+    def state(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._state)
+        return self._state.value
+
+    @property
+    def title(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._title)
+        return self._title.value
+
+    @property
+    def updated_at(self):
+        """
+        :type: datetime.datetime
+        """
+        self._completeIfNotSet(self._updated_at)
+        return self._updated_at.value
+
+    @property
+    def url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._url)
+        return self._url.value
+
+    @property
+    def user(self):
+        """
+        :type: :class:`github.NamedUser.NamedUser`
+        """
+        self._completeIfNotSet(self._user)
+        return self._user.value
+
+    def create_comment(self, body, commit_id, path, position):
+        """
+        :calls: `POST /repos/:owner/:repo/pulls/:number/comments <http://developer.github.com/v3/pulls/comments>`_
+        :param body: string
+        :param commit_id: :class:`github.Commit.Commit`
+        :param path: string
+        :param position: integer
+        :rtype: :class:`github.PullRequestComment.PullRequestComment`
+        """
+        return self.create_review_comment(body, commit_id, path, position)
+
+    def create_review_comment(self, body, commit_id, path, position):
+        """
+        :calls: `POST /repos/:owner/:repo/pulls/:number/comments <http://developer.github.com/v3/pulls/comments>`_
+        :param body: string
+        :param commit_id: :class:`github.Commit.Commit`
+        :param path: string
+        :param position: integer
+        :rtype: :class:`github.PullRequestComment.PullRequestComment`
+        """
+        assert isinstance(body, (str, unicode)), body
+        assert isinstance(commit_id, github.Commit.Commit), commit_id
+        assert isinstance(path, (str, unicode)), path
+        assert isinstance(position, (int, long)), position
+        post_parameters = {
+            "body": body,
+            "commit_id": commit_id._identity,
+            "path": path,
+            "position": position,
+        }
+        headers, data = self._requester.requestJsonAndCheck(
+            "POST",
+            self.url + "/comments",
+            input=post_parameters
+        )
+        return github.PullRequestComment.PullRequestComment(self._requester, headers, data, completed=True)
+
+    def create_issue_comment(self, body):
+        """
+        :calls: `POST /repos/:owner/:repo/issues/:number/comments <http://developer.github.com/v3/issues/comments>`_
+        :param body: string
+        :rtype: :class:`github.IssueComment.IssueComment`
+        """
+        assert isinstance(body, (str, unicode)), body
+        post_parameters = {
+            "body": body,
+        }
+        headers, data = self._requester.requestJsonAndCheck(
+            "POST",
+            self._parentUrl(self._parentUrl(self.url)) + "/issues/" + str(self.number) + "/comments",
+            input=post_parameters
+        )
+        return github.IssueComment.IssueComment(self._requester, headers, data, completed=True)
+
+    def edit(self, title=github.GithubObject.NotSet, body=github.GithubObject.NotSet, state=github.GithubObject.NotSet):
+        """
+        :calls: `PATCH /repos/:owner/:repo/pulls/:number <http://developer.github.com/v3/pulls>`_
+        :param title: string
+        :param body: string
+        :param state: string
+        :rtype: None
+        """
+        assert title is github.GithubObject.NotSet or isinstance(title, (str, unicode)), title
+        assert body is github.GithubObject.NotSet or isinstance(body, (str, unicode)), body
+        assert state is github.GithubObject.NotSet or isinstance(state, (str, unicode)), state
+        post_parameters = dict()
+        if title is not github.GithubObject.NotSet:
+            post_parameters["title"] = title
+        if body is not github.GithubObject.NotSet:
+            post_parameters["body"] = body
+        if state is not github.GithubObject.NotSet:
+            post_parameters["state"] = state
+        headers, data = self._requester.requestJsonAndCheck(
+            "PATCH",
+            self.url,
+            input=post_parameters
+        )
+        self._useAttributes(data)
+
+    def get_comment(self, id):
+        """
+        :calls: `GET /repos/:owner/:repo/pulls/comments/:number <http://developer.github.com/v3/pulls/comments>`_
+        :param id: integer
+        :rtype: :class:`github.PullRequestComment.PullRequestComment`
+        """
+        return self.get_review_comment(id)
+
+    def get_review_comment(self, id):
+        """
+        :calls: `GET /repos/:owner/:repo/pulls/comments/:number <http://developer.github.com/v3/pulls/comments>`_
+        :param id: integer
+        :rtype: :class:`github.PullRequestComment.PullRequestComment`
+        """
+        assert isinstance(id, (int, long)), id
+        headers, data = self._requester.requestJsonAndCheck(
+            "GET",
+            self._parentUrl(self.url) + "/comments/" + str(id)
+        )
+        return github.PullRequestComment.PullRequestComment(self._requester, headers, data, completed=True)
+
+    def get_comments(self):
+        """
+        :calls: `GET /repos/:owner/:repo/pulls/:number/comments <http://developer.github.com/v3/pulls/comments>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.PullRequestComment.PullRequestComment`
+        """
+        return self.get_review_comments()
+
+    def get_review_comments(self):
+        """
+        :calls: `GET /repos/:owner/:repo/pulls/:number/comments <http://developer.github.com/v3/pulls/comments>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.PullRequestComment.PullRequestComment`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.PullRequestComment.PullRequestComment,
+            self._requester,
+            self.url + "/comments",
+            None
+        )
+
+    def get_commits(self):
+        """
+        :calls: `GET /repos/:owner/:repo/pulls/:number/commits <http://developer.github.com/v3/pulls>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Commit.Commit`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.Commit.Commit,
+            self._requester,
+            self.url + "/commits",
+            None
+        )
+
+    def get_files(self):
+        """
+        :calls: `GET /repos/:owner/:repo/pulls/:number/files <http://developer.github.com/v3/pulls>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.File.File`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.File.File,
+            self._requester,
+            self.url + "/files",
+            None
+        )
+
+    def get_issue_comment(self, id):
+        """
+        :calls: `GET /repos/:owner/:repo/issues/comments/:id <http://developer.github.com/v3/issues/comments>`_
+        :param id: integer
+        :rtype: :class:`github.IssueComment.IssueComment`
+        """
+        assert isinstance(id, (int, long)), id
+        headers, data = self._requester.requestJsonAndCheck(
+            "GET",
+            self._parentUrl(self._parentUrl(self.url)) + "/issues/comments/" + str(id)
+        )
+        return github.IssueComment.IssueComment(self._requester, headers, data, completed=True)
+
+    def get_issue_comments(self):
+        """
+        :calls: `GET /repos/:owner/:repo/issues/:number/comments <http://developer.github.com/v3/issues/comments>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.IssueComment.IssueComment`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.IssueComment.IssueComment,
+            self._requester,
+            self._parentUrl(self._parentUrl(self.url)) + "/issues/" + str(self.number) + "/comments",
+            None
+        )
+
+    def is_merged(self):
+        """
+        :calls: `GET /repos/:owner/:repo/pulls/:number/merge <http://developer.github.com/v3/pulls>`_
+        :rtype: bool
+        """
+        status, headers, data = self._requester.requestJson(
+            "GET",
+            self.url + "/merge"
+        )
+        return status == 204
+
+    def merge(self, commit_message=github.GithubObject.NotSet):
+        """
+        :calls: `PUT /repos/:owner/:repo/pulls/:number/merge <http://developer.github.com/v3/pulls>`_
+        :param commit_message: string
+        :rtype: :class:`github.PullRequestMergeStatus.PullRequestMergeStatus`
+        """
+        assert commit_message is github.GithubObject.NotSet or isinstance(commit_message, (str, unicode)), commit_message
+        post_parameters = dict()
+        if commit_message is not github.GithubObject.NotSet:
+            post_parameters["commit_message"] = commit_message
+        headers, data = self._requester.requestJsonAndCheck(
+            "PUT",
+            self.url + "/merge",
+            input=post_parameters
+        )
+        return github.PullRequestMergeStatus.PullRequestMergeStatus(self._requester, headers, data, completed=True)
+
+    def _initAttributes(self):
+        self._additions = github.GithubObject.NotSet
+        self._assignee = github.GithubObject.NotSet
+        self._base = github.GithubObject.NotSet
+        self._body = github.GithubObject.NotSet
+        self._changed_files = github.GithubObject.NotSet
+        self._closed_at = github.GithubObject.NotSet
+        self._comments = github.GithubObject.NotSet
+        self._comments_url = github.GithubObject.NotSet
+        self._commits = github.GithubObject.NotSet
+        self._commits_url = github.GithubObject.NotSet
+        self._created_at = github.GithubObject.NotSet
+        self._deletions = github.GithubObject.NotSet
+        self._diff_url = github.GithubObject.NotSet
+        self._head = github.GithubObject.NotSet
+        self._html_url = github.GithubObject.NotSet
+        self._id = github.GithubObject.NotSet
+        self._issue_url = github.GithubObject.NotSet
+        self._merge_commit_sha = github.GithubObject.NotSet
+        self._mergeable = github.GithubObject.NotSet
+        self._mergeable_state = github.GithubObject.NotSet
+        self._merged = github.GithubObject.NotSet
+        self._merged_at = github.GithubObject.NotSet
+        self._merged_by = github.GithubObject.NotSet
+        self._milestone = github.GithubObject.NotSet
+        self._number = github.GithubObject.NotSet
+        self._patch_url = github.GithubObject.NotSet
+        self._review_comment_url = github.GithubObject.NotSet
+        self._review_comments = github.GithubObject.NotSet
+        self._review_comments_url = github.GithubObject.NotSet
+        self._state = github.GithubObject.NotSet
+        self._title = github.GithubObject.NotSet
+        self._updated_at = github.GithubObject.NotSet
+        self._url = github.GithubObject.NotSet
+        self._user = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "additions" in attributes:  # pragma no branch
+            self._additions = self._makeIntAttribute(attributes["additions"])
+        if "assignee" in attributes:  # pragma no branch
+            self._assignee = self._makeClassAttribute(github.NamedUser.NamedUser, attributes["assignee"])
+        if "base" in attributes:  # pragma no branch
+            self._base = self._makeClassAttribute(github.PullRequestPart.PullRequestPart, attributes["base"])
+        if "body" in attributes:  # pragma no branch
+            self._body = self._makeStringAttribute(attributes["body"])
+        if "changed_files" in attributes:  # pragma no branch
+            self._changed_files = self._makeIntAttribute(attributes["changed_files"])
+        if "closed_at" in attributes:  # pragma no branch
+            self._closed_at = self._makeDatetimeAttribute(attributes["closed_at"])
+        if "comments" in attributes:  # pragma no branch
+            self._comments = self._makeIntAttribute(attributes["comments"])
+        if "comments_url" in attributes:  # pragma no branch
+            self._comments_url = self._makeStringAttribute(attributes["comments_url"])
+        if "commits" in attributes:  # pragma no branch
+            self._commits = self._makeIntAttribute(attributes["commits"])
+        if "commits_url" in attributes:  # pragma no branch
+            self._commits_url = self._makeStringAttribute(attributes["commits_url"])
+        if "created_at" in attributes:  # pragma no branch
+            self._created_at = self._makeDatetimeAttribute(attributes["created_at"])
+        if "deletions" in attributes:  # pragma no branch
+            self._deletions = self._makeIntAttribute(attributes["deletions"])
+        if "diff_url" in attributes:  # pragma no branch
+            self._diff_url = self._makeStringAttribute(attributes["diff_url"])
+        if "head" in attributes:  # pragma no branch
+            self._head = self._makeClassAttribute(github.PullRequestPart.PullRequestPart, attributes["head"])
+        if "html_url" in attributes:  # pragma no branch
+            self._html_url = self._makeStringAttribute(attributes["html_url"])
+        if "id" in attributes:  # pragma no branch
+            self._id = self._makeIntAttribute(attributes["id"])
+        if "issue_url" in attributes:  # pragma no branch
+            self._issue_url = self._makeStringAttribute(attributes["issue_url"])
+        if "merge_commit_sha" in attributes:  # pragma no branch
+            self._merge_commit_sha = self._makeStringAttribute(attributes["merge_commit_sha"])
+        if "mergeable" in attributes:  # pragma no branch
+            self._mergeable = self._makeBoolAttribute(attributes["mergeable"])
+        if "mergeable_state" in attributes:  # pragma no branch
+            self._mergeable_state = self._makeStringAttribute(attributes["mergeable_state"])
+        if "merged" in attributes:  # pragma no branch
+            self._merged = self._makeBoolAttribute(attributes["merged"])
+        if "merged_at" in attributes:  # pragma no branch
+            self._merged_at = self._makeDatetimeAttribute(attributes["merged_at"])
+        if "merged_by" in attributes:  # pragma no branch
+            self._merged_by = self._makeClassAttribute(github.NamedUser.NamedUser, attributes["merged_by"])
+        if "milestone" in attributes:  # pragma no branch
+            self._milestone = self._makeClassAttribute(github.Milestone.Milestone, attributes["milestone"])
+        if "number" in attributes:  # pragma no branch
+            self._number = self._makeIntAttribute(attributes["number"])
+        if "patch_url" in attributes:  # pragma no branch
+            self._patch_url = self._makeStringAttribute(attributes["patch_url"])
+        if "review_comment_url" in attributes:  # pragma no branch
+            self._review_comment_url = self._makeStringAttribute(attributes["review_comment_url"])
+        if "review_comments" in attributes:  # pragma no branch
+            self._review_comments = self._makeIntAttribute(attributes["review_comments"])
+        if "review_comments_url" in attributes:  # pragma no branch
+            self._review_comments_url = self._makeStringAttribute(attributes["review_comments_url"])
+        if "state" in attributes:  # pragma no branch
+            self._state = self._makeStringAttribute(attributes["state"])
+        if "title" in attributes:  # pragma no branch
+            self._title = self._makeStringAttribute(attributes["title"])
+        if "updated_at" in attributes:  # pragma no branch
+            self._updated_at = self._makeDatetimeAttribute(attributes["updated_at"])
+        if "url" in attributes:  # pragma no branch
+            self._url = self._makeStringAttribute(attributes["url"])
+        if "user" in attributes:  # pragma no branch
+            self._user = self._makeClassAttribute(github.NamedUser.NamedUser, attributes["user"])

--- a/github/PullRequestComment.py
+++ b/github/PullRequestComment.py
@@ -1,0 +1,222 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Michael Stead <michael.stead@gmail.com>                       #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2013 martinqt <m.ki2@laposte.net>                                  #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+
+import github.NamedUser
+
+
+class PullRequestComment(github.GithubObject.CompletableGithubObject):
+    """
+    This class represents PullRequestComments. The reference can be found here http://developer.github.com/v3/pulls/comments/
+    """
+
+    @property
+    def body(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._body)
+        return self._body.value
+
+    @property
+    def commit_id(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._commit_id)
+        return self._commit_id.value
+
+    @property
+    def created_at(self):
+        """
+        :type: datetime.datetime
+        """
+        self._completeIfNotSet(self._created_at)
+        return self._created_at.value
+
+    @property
+    def diff_hunk(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._diff_hunk)
+        return self._diff_hunk.value
+
+    @property
+    def id(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._id)
+        return self._id.value
+
+    @property
+    def original_commit_id(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._original_commit_id)
+        return self._original_commit_id.value
+
+    @property
+    def original_position(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._original_position)
+        return self._original_position.value
+
+    @property
+    def path(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._path)
+        return self._path.value
+
+    @property
+    def position(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._position)
+        return self._position.value
+
+    @property
+    def pull_request_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._pull_request_url)
+        return self._pull_request_url.value
+
+    @property
+    def updated_at(self):
+        """
+        :type: datetime.datetime
+        """
+        self._completeIfNotSet(self._updated_at)
+        return self._updated_at.value
+
+    @property
+    def url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._url)
+        return self._url.value
+
+    @property
+    def html_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._html_url)
+        return self._html_url.value
+
+    @property
+    def user(self):
+        """
+        :type: :class:`github.NamedUser.NamedUser`
+        """
+        self._completeIfNotSet(self._user)
+        return self._user.value
+
+    def delete(self):
+        """
+        :calls: `DELETE /repos/:owner/:repo/pulls/comments/:number <http://developer.github.com/v3/pulls/comments>`_
+        :rtype: None
+        """
+        headers, data = self._requester.requestJsonAndCheck(
+            "DELETE",
+            self.url
+        )
+
+    def edit(self, body):
+        """
+        :calls: `PATCH /repos/:owner/:repo/pulls/comments/:number <http://developer.github.com/v3/pulls/comments>`_
+        :param body: string
+        :rtype: None
+        """
+        assert isinstance(body, (str, unicode)), body
+        post_parameters = {
+            "body": body,
+        }
+        headers, data = self._requester.requestJsonAndCheck(
+            "PATCH",
+            self.url,
+            input=post_parameters
+        )
+        self._useAttributes(data)
+
+    def _initAttributes(self):
+        self._body = github.GithubObject.NotSet
+        self._commit_id = github.GithubObject.NotSet
+        self._created_at = github.GithubObject.NotSet
+        self._diff_hunk = github.GithubObject.NotSet
+        self._id = github.GithubObject.NotSet
+        self._original_commit_id = github.GithubObject.NotSet
+        self._original_position = github.GithubObject.NotSet
+        self._path = github.GithubObject.NotSet
+        self._position = github.GithubObject.NotSet
+        self._pull_request_url = github.GithubObject.NotSet
+        self._updated_at = github.GithubObject.NotSet
+        self._url = github.GithubObject.NotSet
+        self._html_url = github.GithubObject.NotSet
+        self._user = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "body" in attributes:  # pragma no branch
+            self._body = self._makeStringAttribute(attributes["body"])
+        if "commit_id" in attributes:  # pragma no branch
+            self._commit_id = self._makeStringAttribute(attributes["commit_id"])
+        if "created_at" in attributes:  # pragma no branch
+            self._created_at = self._makeDatetimeAttribute(attributes["created_at"])
+        if "diff_hunk" in attributes:  # pragma no branch
+            self._diff_hunk = self._makeStringAttribute(attributes["diff_hunk"])
+        if "id" in attributes:  # pragma no branch
+            self._id = self._makeIntAttribute(attributes["id"])
+        if "original_commit_id" in attributes:  # pragma no branch
+            self._original_commit_id = self._makeStringAttribute(attributes["original_commit_id"])
+        if "original_position" in attributes:  # pragma no branch
+            self._original_position = self._makeIntAttribute(attributes["original_position"])
+        if "path" in attributes:  # pragma no branch
+            self._path = self._makeStringAttribute(attributes["path"])
+        if "position" in attributes:  # pragma no branch
+            self._position = self._makeIntAttribute(attributes["position"])
+        if "pull_request_url" in attributes:  # pragma no branch
+            self._pull_request_url = self._makeStringAttribute(attributes["pull_request_url"])
+        if "updated_at" in attributes:  # pragma no branch
+            self._updated_at = self._makeDatetimeAttribute(attributes["updated_at"])
+        if "url" in attributes:  # pragma no branch
+            self._url = self._makeStringAttribute(attributes["url"])
+        if "html_url" in attributes:  # pragma no branch
+            self._html_url = self._makeStringAttribute(attributes["html_url"])
+        if "user" in attributes:  # pragma no branch
+            self._user = self._makeClassAttribute(github.NamedUser.NamedUser, attributes["user"])

--- a/github/PullRequestMergeStatus.py
+++ b/github/PullRequestMergeStatus.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2013 martinqt <m.ki2@laposte.net>                                  #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+
+
+class PullRequestMergeStatus(github.GithubObject.NonCompletableGithubObject):
+    """
+    This class represents PullRequestMergeStatuss. The reference can be found here http://developer.github.com/v3/pulls/#get-if-a-pull-request-has-been-merged
+    """
+
+    @property
+    def merged(self):
+        """
+        :type: bool
+        """
+        return self._merged.value
+
+    @property
+    def message(self):
+        """
+        :type: string
+        """
+        return self._message.value
+
+    @property
+    def sha(self):
+        """
+        :type: string
+        """
+        return self._sha.value
+
+    def _initAttributes(self):
+        self._merged = github.GithubObject.NotSet
+        self._message = github.GithubObject.NotSet
+        self._sha = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "merged" in attributes:  # pragma no branch
+            self._merged = self._makeBoolAttribute(attributes["merged"])
+        if "message" in attributes:  # pragma no branch
+            self._message = self._makeStringAttribute(attributes["message"])
+        if "sha" in attributes:  # pragma no branch
+            self._sha = self._makeStringAttribute(attributes["sha"])

--- a/github/PullRequestPart.py
+++ b/github/PullRequestPart.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+
+import github.Repository
+import github.NamedUser
+
+
+class PullRequestPart(github.GithubObject.NonCompletableGithubObject):
+    """
+    This class represents PullRequestParts as returned for example by http://developer.github.com/v3/todo
+    """
+
+    @property
+    def label(self):
+        """
+        :type: string
+        """
+        return self._label.value
+
+    @property
+    def ref(self):
+        """
+        :type: string
+        """
+        return self._ref.value
+
+    @property
+    def repo(self):
+        """
+        :type: :class:`github.Repository.Repository`
+        """
+        return self._repo.value
+
+    @property
+    def sha(self):
+        """
+        :type: string
+        """
+        return self._sha.value
+
+    @property
+    def user(self):
+        """
+        :type: :class:`github.NamedUser.NamedUser`
+        """
+        return self._user.value
+
+    def _initAttributes(self):
+        self._label = github.GithubObject.NotSet
+        self._ref = github.GithubObject.NotSet
+        self._repo = github.GithubObject.NotSet
+        self._sha = github.GithubObject.NotSet
+        self._user = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "label" in attributes:  # pragma no branch
+            self._label = self._makeStringAttribute(attributes["label"])
+        if "ref" in attributes:  # pragma no branch
+            self._ref = self._makeStringAttribute(attributes["ref"])
+        if "repo" in attributes:  # pragma no branch
+            self._repo = self._makeClassAttribute(github.Repository.Repository, attributes["repo"])
+        if "sha" in attributes:  # pragma no branch
+            self._sha = self._makeStringAttribute(attributes["sha"])
+        if "user" in attributes:  # pragma no branch
+            self._user = self._makeClassAttribute(github.NamedUser.NamedUser, attributes["user"])

--- a/github/Rate.py
+++ b/github/Rate.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+import datetime
+
+
+class Rate(github.GithubObject.NonCompletableGithubObject):
+    """
+    This class represents rate limits as defined in http://developer.github.com/v3/rate_limit
+    """
+
+    @property
+    def limit(self):
+        """
+        :type: integer
+        """
+        return self._limit.value
+
+    @property
+    def remaining(self):
+        """
+        :type: integer
+        """
+        return self._remaining.value
+
+    @property
+    def reset(self):
+        """
+        :type: datetime.datetime
+        """
+        return self._reset.value
+
+    def _initAttributes(self):
+        self._limit = github.GithubObject.NotSet
+        self._remaining = github.GithubObject.NotSet
+        self._reset = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "limit" in attributes:  # pragma no branch
+            self._limit = self._makeIntAttribute(attributes["limit"])
+        if "remaining" in attributes:  # pragma no branch
+            self._remaining = self._makeIntAttribute(attributes["remaining"])
+        if "reset" in attributes:  # pragma no branch
+            self._reset = self._makeTimestampAttribute(attributes["reset"])

--- a/github/RateLimit.py
+++ b/github/RateLimit.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+import github.Rate
+
+
+class RateLimit(github.GithubObject.NonCompletableGithubObject):
+    """
+    This class represents rate limits as defined in http://developer.github.com/v3/rate_limit
+    """
+
+    @property
+    def rate(self):
+        """
+        :type: class:`github.Rate.Rate`
+        """
+        return self._rate.value
+
+    def _initAttributes(self):
+        self._rate = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "rate" in attributes:  # pragma no branch
+            self._rate = self._makeClassAttribute(github.Rate.Rate, attributes["rate"])

--- a/github/Repository.py
+++ b/github/Repository.py
@@ -1,0 +1,2268 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Christopher Gilbert <christopher.john.gilbert@gmail.com>      #
+# Copyright 2012 Steve English <steve.english@navetas.com>                     #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Adrian Petrescu <adrian.petrescu@maluuba.com>                 #
+# Copyright 2013 Mark Roddy <markroddy@gmail.com>                              #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2013 martinqt <m.ki2@laposte.net>                                  #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import urllib
+import datetime
+
+import github.GithubObject
+import github.PaginatedList
+
+import github.Branch
+import github.IssueEvent
+import github.ContentFile
+import github.Label
+import github.GitBlob
+import github.Organization
+import github.GitRef
+import github.GitRelease
+import github.Issue
+import github.Repository
+import github.PullRequest
+import github.RepositoryKey
+import github.NamedUser
+import github.Milestone
+import github.Comparison
+import github.CommitComment
+import github.GitCommit
+import github.Team
+import github.Commit
+import github.GitTree
+import github.Hook
+import github.Tag
+import github.GitTag
+import github.Download
+import github.Permissions
+import github.Event
+import github.Legacy
+import github.StatsContributor
+import github.StatsCommitActivity
+import github.StatsCodeFrequency
+import github.StatsParticipation
+import github.StatsPunchCard
+import github.Stargazer
+
+
+class Repository(github.GithubObject.CompletableGithubObject):
+    """
+    This class represents Repositorys. The reference can be found here http://developer.github.com/v3/repos/
+    """
+
+    @property
+    def archive_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._archive_url)
+        return self._archive_url.value
+
+    @property
+    def assignees_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._assignees_url)
+        return self._assignees_url.value
+
+    @property
+    def blobs_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._blobs_url)
+        return self._blobs_url.value
+
+    @property
+    def branches_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._branches_url)
+        return self._branches_url.value
+
+    @property
+    def clone_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._clone_url)
+        return self._clone_url.value
+
+    @property
+    def collaborators_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._collaborators_url)
+        return self._collaborators_url.value
+
+    @property
+    def comments_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._comments_url)
+        return self._comments_url.value
+
+    @property
+    def commits_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._commits_url)
+        return self._commits_url.value
+
+    @property
+    def compare_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._compare_url)
+        return self._compare_url.value
+
+    @property
+    def contents_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._contents_url)
+        return self._contents_url.value
+
+    @property
+    def contributors_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._contributors_url)
+        return self._contributors_url.value
+
+    @property
+    def created_at(self):
+        """
+        :type: datetime.datetime
+        """
+        self._completeIfNotSet(self._created_at)
+        return self._created_at.value
+
+    @property
+    def default_branch(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._default_branch)
+        return self._default_branch.value
+
+    @property
+    def description(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._description)
+        return self._description.value
+
+    @property
+    def downloads_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._downloads_url)
+        return self._downloads_url.value
+
+    @property
+    def events_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._events_url)
+        return self._events_url.value
+
+    @property
+    def fork(self):
+        """
+        :type: bool
+        """
+        self._completeIfNotSet(self._fork)
+        return self._fork.value
+
+    @property
+    def forks(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._forks)
+        return self._forks.value
+
+    @property
+    def forks_count(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._forks_count)
+        return self._forks_count.value
+
+    @property
+    def forks_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._forks_url)
+        return self._forks_url.value
+
+    @property
+    def full_name(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._full_name)
+        return self._full_name.value
+
+    @property
+    def git_commits_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._git_commits_url)
+        return self._git_commits_url.value
+
+    @property
+    def git_refs_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._git_refs_url)
+        return self._git_refs_url.value
+
+    @property
+    def git_tags_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._git_tags_url)
+        return self._git_tags_url.value
+
+    @property
+    def git_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._git_url)
+        return self._git_url.value
+
+    @property
+    def has_downloads(self):
+        """
+        :type: bool
+        """
+        self._completeIfNotSet(self._has_downloads)
+        return self._has_downloads.value
+
+    @property
+    def has_issues(self):
+        """
+        :type: bool
+        """
+        self._completeIfNotSet(self._has_issues)
+        return self._has_issues.value
+
+    @property
+    def has_wiki(self):
+        """
+        :type: bool
+        """
+        self._completeIfNotSet(self._has_wiki)
+        return self._has_wiki.value
+
+    @property
+    def homepage(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._homepage)
+        return self._homepage.value
+
+    @property
+    def hooks_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._hooks_url)
+        return self._hooks_url.value
+
+    @property
+    def html_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._html_url)
+        return self._html_url.value
+
+    @property
+    def id(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._id)
+        return self._id.value
+
+    @property
+    def issue_comment_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._issue_comment_url)
+        return self._issue_comment_url.value
+
+    @property
+    def issue_events_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._issue_events_url)
+        return self._issue_events_url.value
+
+    @property
+    def issues_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._issues_url)
+        return self._issues_url.value
+
+    @property
+    def keys_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._keys_url)
+        return self._keys_url.value
+
+    @property
+    def labels_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._labels_url)
+        return self._labels_url.value
+
+    @property
+    def language(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._language)
+        return self._language.value
+
+    @property
+    def languages_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._languages_url)
+        return self._languages_url.value
+
+    @property
+    def master_branch(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._master_branch)
+        return self._master_branch.value
+
+    @property
+    def merges_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._merges_url)
+        return self._merges_url.value
+
+    @property
+    def milestones_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._milestones_url)
+        return self._milestones_url.value
+
+    @property
+    def mirror_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._mirror_url)
+        return self._mirror_url.value
+
+    @property
+    def name(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._name)
+        return self._name.value
+
+    @property
+    def network_count(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._network_count)
+        return self._network_count.value
+
+    @property
+    def notifications_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._notifications_url)
+        return self._notifications_url.value
+
+    @property
+    def open_issues(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._open_issues)
+        return self._open_issues.value
+
+    @property
+    def open_issues_count(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._open_issues_count)
+        return self._open_issues_count.value
+
+    @property
+    def organization(self):
+        """
+        :type: :class:`github.Organization.Organization`
+        """
+        self._completeIfNotSet(self._organization)
+        return self._organization.value
+
+    @property
+    def owner(self):
+        """
+        :type: :class:`github.NamedUser.NamedUser`
+        """
+        self._completeIfNotSet(self._owner)
+        return self._owner.value
+
+    @property
+    def parent(self):
+        """
+        :type: :class:`github.Repository.Repository`
+        """
+        self._completeIfNotSet(self._parent)
+        return self._parent.value
+
+    @property
+    def permissions(self):
+        """
+        :type: :class:`github.Permissions.Permissions`
+        """
+        self._completeIfNotSet(self._permissions)
+        return self._permissions.value
+
+    @property
+    def private(self):
+        """
+        :type: bool
+        """
+        self._completeIfNotSet(self._private)
+        return self._private.value
+
+    @property
+    def pulls_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._pulls_url)
+        return self._pulls_url.value
+
+    @property
+    def pushed_at(self):
+        """
+        :type: datetime.datetime
+        """
+        self._completeIfNotSet(self._pushed_at)
+        return self._pushed_at.value
+
+    @property
+    def size(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._size)
+        return self._size.value
+
+    @property
+    def source(self):
+        """
+        :type: :class:`github.Repository.Repository`
+        """
+        self._completeIfNotSet(self._source)
+        return self._source.value
+
+    @property
+    def ssh_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._ssh_url)
+        return self._ssh_url.value
+
+    @property
+    def stargazers_count(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._stargazers_count)  # pragma no cover (Should be covered)
+        return self._stargazers_count.value  # pragma no cover (Should be covered)
+
+    @property
+    def stargazers_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._stargazers_url)
+        return self._stargazers_url.value
+
+    @property
+    def statuses_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._statuses_url)
+        return self._statuses_url.value
+
+    @property
+    def subscribers_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._subscribers_url)
+        return self._subscribers_url.value
+
+    @property
+    def subscription_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._subscription_url)
+        return self._subscription_url.value
+
+    @property
+    def svn_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._svn_url)
+        return self._svn_url.value
+
+    @property
+    def tags_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._tags_url)
+        return self._tags_url.value
+
+    @property
+    def teams_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._teams_url)
+        return self._teams_url.value
+
+    @property
+    def trees_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._trees_url)
+        return self._trees_url.value
+
+    @property
+    def updated_at(self):
+        """
+        :type: datetime.datetime
+        """
+        self._completeIfNotSet(self._updated_at)
+        return self._updated_at.value
+
+    @property
+    def url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._url)
+        return self._url.value
+
+    @property
+    def watchers(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._watchers)
+        return self._watchers.value
+
+    @property
+    def watchers_count(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._watchers_count)
+        return self._watchers_count.value
+
+    def add_to_collaborators(self, collaborator):
+        """
+        :calls: `PUT /repos/:owner/:repo/collaborators/:user <http://developer.github.com/v3/repos/collaborators>`_
+        :param collaborator: string or :class:`github.NamedUser.NamedUser`
+        :rtype: None
+        """
+        assert isinstance(collaborator, github.NamedUser.NamedUser) or isinstance(collaborator, (str, unicode)), collaborator
+
+        if isinstance(collaborator, github.NamedUser.NamedUser):
+            collaborator = collaborator._identity
+
+        headers, data = self._requester.requestJsonAndCheck(
+            "PUT",
+            self.url + "/collaborators/" + collaborator
+        )
+
+    def compare(self, base, head):
+        """
+        :calls: `GET /repos/:owner/:repo/compare/:base...:head <http://developer.github.com/v3/repos/commits>`_
+        :param base: string
+        :param head: string
+        :rtype: :class:`github.Comparison.Comparison`
+        """
+        assert isinstance(base, (str, unicode)), base
+        assert isinstance(head, (str, unicode)), head
+        headers, data = self._requester.requestJsonAndCheck(
+            "GET",
+            self.url + "/compare/" + base + "..." + head
+        )
+        return github.Comparison.Comparison(self._requester, headers, data, completed=True)
+
+    def create_git_blob(self, content, encoding):
+        """
+        :calls: `POST /repos/:owner/:repo/git/blobs <http://developer.github.com/v3/git/blobs>`_
+        :param content: string
+        :param encoding: string
+        :rtype: :class:`github.GitBlob.GitBlob`
+        """
+        assert isinstance(content, (str, unicode)), content
+        assert isinstance(encoding, (str, unicode)), encoding
+        post_parameters = {
+            "content": content,
+            "encoding": encoding,
+        }
+        headers, data = self._requester.requestJsonAndCheck(
+            "POST",
+            self.url + "/git/blobs",
+            input=post_parameters
+        )
+        return github.GitBlob.GitBlob(self._requester, headers, data, completed=True)
+
+    def create_git_commit(self, message, tree, parents, author=github.GithubObject.NotSet, committer=github.GithubObject.NotSet):
+        """
+        :calls: `POST /repos/:owner/:repo/git/commits <http://developer.github.com/v3/git/commits>`_
+        :param message: string
+        :param tree: :class:`github.GitTree.GitTree`
+        :param parents: list of :class:`github.GitCommit.GitCommit`
+        :param author: :class:`github.InputGitAuthor.InputGitAuthor`
+        :param committer: :class:`github.InputGitAuthor.InputGitAuthor`
+        :rtype: :class:`github.GitCommit.GitCommit`
+        """
+        assert isinstance(message, (str, unicode)), message
+        assert isinstance(tree, github.GitTree.GitTree), tree
+        assert all(isinstance(element, github.GitCommit.GitCommit) for element in parents), parents
+        assert author is github.GithubObject.NotSet or isinstance(author, github.InputGitAuthor), author
+        assert committer is github.GithubObject.NotSet or isinstance(committer, github.InputGitAuthor), committer
+        post_parameters = {
+            "message": message,
+            "tree": tree._identity,
+            "parents": [element._identity for element in parents],
+        }
+        if author is not github.GithubObject.NotSet:
+            post_parameters["author"] = author._identity
+        if committer is not github.GithubObject.NotSet:
+            post_parameters["committer"] = committer._identity
+        headers, data = self._requester.requestJsonAndCheck(
+            "POST",
+            self.url + "/git/commits",
+            input=post_parameters
+        )
+        return github.GitCommit.GitCommit(self._requester, headers, data, completed=True)
+
+    def create_git_ref(self, ref, sha):
+        """
+        :calls: `POST /repos/:owner/:repo/git/refs <http://developer.github.com/v3/git/refs>`_
+        :param ref: string
+        :param sha: string
+        :rtype: :class:`github.GitRef.GitRef`
+        """
+        assert isinstance(ref, (str, unicode)), ref
+        assert isinstance(sha, (str, unicode)), sha
+        post_parameters = {
+            "ref": ref,
+            "sha": sha,
+        }
+        headers, data = self._requester.requestJsonAndCheck(
+            "POST",
+            self.url + "/git/refs",
+            input=post_parameters
+        )
+        return github.GitRef.GitRef(self._requester, headers, data, completed=True)
+
+    def create_git_tag_and_release(self, tag, tag_message, release_name, release_message, object, type, tagger=github.GithubObject.NotSet, draft=False, prerelease=False):
+        self.create_git_tag(tag, tag_message, object, type, tagger)
+        return self.create_git_release(tag, release_name, release_message, draft, prerelease)
+
+    def create_git_release(self, tag, name, message, draft=False, prerelease=False):
+        assert isinstance(tag, (str, unicode)), tag
+        assert isinstance(name, (str, unicode)), name
+        assert isinstance(message, (str, unicode)), message
+        assert isinstance(draft, bool), draft
+        assert isinstance(prerelease, bool), prerelease
+        post_parameters = {
+            "tag_name": tag,
+            "name": name,
+            "body": message,
+            "draft": draft,
+            "prerelease": prerelease,
+        }
+        headers, data = self._requester.requestJsonAndCheck(
+            "POST",
+            self.url + "/releases",
+            input=post_parameters
+        )
+        return github.GitRelease.GitRelease(self._requester, headers, data, completed=True)
+
+    def create_git_tag(self, tag, message, object, type, tagger=github.GithubObject.NotSet):
+        """
+        :calls: `POST /repos/:owner/:repo/git/tags <http://developer.github.com/v3/git/tags>`_
+        :param tag: string
+        :param message: string
+        :param object: string
+        :param type: string
+        :param tagger: :class:`github.InputGitAuthor.InputGitAuthor`
+        :rtype: :class:`github.GitTag.GitTag`
+        """
+        assert isinstance(tag, (str, unicode)), tag
+        assert isinstance(message, (str, unicode)), message
+        assert isinstance(object, (str, unicode)), object
+        assert isinstance(type, (str, unicode)), type
+        assert tagger is github.GithubObject.NotSet or isinstance(tagger, github.InputGitAuthor), tagger
+        post_parameters = {
+            "tag": tag,
+            "message": message,
+            "object": object,
+            "type": type,
+        }
+        if tagger is not github.GithubObject.NotSet:
+            post_parameters["tagger"] = tagger._identity
+        headers, data = self._requester.requestJsonAndCheck(
+            "POST",
+            self.url + "/git/tags",
+            input=post_parameters
+        )
+        return github.GitTag.GitTag(self._requester, headers, data, completed=True)
+
+    def create_git_tree(self, tree, base_tree=github.GithubObject.NotSet):
+        """
+        :calls: `POST /repos/:owner/:repo/git/trees <http://developer.github.com/v3/git/trees>`_
+        :param tree: list of :class:`github.InputGitTreeElement.InputGitTreeElement`
+        :param base_tree: :class:`github.GitTree.GitTree`
+        :rtype: :class:`github.GitTree.GitTree`
+        """
+        assert all(isinstance(element, github.InputGitTreeElement) for element in tree), tree
+        assert base_tree is github.GithubObject.NotSet or isinstance(base_tree, github.GitTree.GitTree), base_tree
+        post_parameters = {
+            "tree": [element._identity for element in tree],
+        }
+        if base_tree is not github.GithubObject.NotSet:
+            post_parameters["base_tree"] = base_tree._identity
+        headers, data = self._requester.requestJsonAndCheck(
+            "POST",
+            self.url + "/git/trees",
+            input=post_parameters
+        )
+        return github.GitTree.GitTree(self._requester, headers, data, completed=True)
+
+    def create_hook(self, name, config, events=github.GithubObject.NotSet, active=github.GithubObject.NotSet):
+        """
+        :calls: `POST /repos/:owner/:repo/hooks <http://developer.github.com/v3/repos/hooks>`_
+        :param name: string
+        :param config: dict
+        :param events: list of string
+        :param active: bool
+        :rtype: :class:`github.Hook.Hook`
+        """
+        assert isinstance(name, (str, unicode)), name
+        assert isinstance(config, dict), config
+        assert events is github.GithubObject.NotSet or all(isinstance(element, (str, unicode)) for element in events), events
+        assert active is github.GithubObject.NotSet or isinstance(active, bool), active
+        post_parameters = {
+            "name": name,
+            "config": config,
+        }
+        if events is not github.GithubObject.NotSet:
+            post_parameters["events"] = events
+        if active is not github.GithubObject.NotSet:
+            post_parameters["active"] = active
+        headers, data = self._requester.requestJsonAndCheck(
+            "POST",
+            self.url + "/hooks",
+            input=post_parameters
+        )
+        return github.Hook.Hook(self._requester, headers, data, completed=True)
+
+    def create_issue(self, title, body=github.GithubObject.NotSet, assignee=github.GithubObject.NotSet, milestone=github.GithubObject.NotSet, labels=github.GithubObject.NotSet):
+        """
+        :calls: `POST /repos/:owner/:repo/issues <http://developer.github.com/v3/issues>`_
+        :param title: string
+        :param body: string
+        :param assignee: string or :class:`github.NamedUser.NamedUser`
+        :param milestone: :class:`github.Milestone.Milestone`
+        :param labels: list of :class:`github.Label.Label`
+        :rtype: :class:`github.Issue.Issue`
+        """
+        assert isinstance(title, (str, unicode)), title
+        assert body is github.GithubObject.NotSet or isinstance(body, (str, unicode)), body
+        assert assignee is github.GithubObject.NotSet or isinstance(assignee, github.NamedUser.NamedUser) or isinstance(assignee, (str, unicode)), assignee
+        assert milestone is github.GithubObject.NotSet or isinstance(milestone, github.Milestone.Milestone), milestone
+        assert labels is github.GithubObject.NotSet or all(isinstance(element, github.Label.Label) or isinstance(element, str) for element in labels), labels
+
+        post_parameters = {
+            "title": title,
+        }
+        if body is not github.GithubObject.NotSet:
+            post_parameters["body"] = body
+        if assignee is not github.GithubObject.NotSet:
+            if isinstance(assignee, (str, unicode)):
+                post_parameters["assignee"] = assignee
+            else:
+                post_parameters["assignee"] = assignee._identity
+        if milestone is not github.GithubObject.NotSet:
+            post_parameters["milestone"] = milestone._identity
+        if labels is not github.GithubObject.NotSet:
+            post_parameters["labels"] = [element.name if isinstance(element, github.Label.Label) else element for element in labels]
+        headers, data = self._requester.requestJsonAndCheck(
+            "POST",
+            self.url + "/issues",
+            input=post_parameters
+        )
+        return github.Issue.Issue(self._requester, headers, data, completed=True)
+
+    def create_key(self, title, key):
+        """
+        :calls: `POST /repos/:owner/:repo/keys <http://developer.github.com/v3/repos/keys>`_
+        :param title: string
+        :param key: string
+        :rtype: :class:`github.RepositoryKey.RepositoryKey`
+        """
+        assert isinstance(title, (str, unicode)), title
+        assert isinstance(key, (str, unicode)), key
+        post_parameters = {
+            "title": title,
+            "key": key,
+        }
+        headers, data = self._requester.requestJsonAndCheck(
+            "POST",
+            self.url + "/keys",
+            input=post_parameters
+        )
+        return github.RepositoryKey.RepositoryKey(self._requester, headers, data, completed=True, repoUrl=self.url)
+
+    def create_label(self, name, color):
+        """
+        :calls: `POST /repos/:owner/:repo/labels <http://developer.github.com/v3/issues/labels>`_
+        :param name: string
+        :param color: string
+        :rtype: :class:`github.Label.Label`
+        """
+        assert isinstance(name, (str, unicode)), name
+        assert isinstance(color, (str, unicode)), color
+        post_parameters = {
+            "name": name,
+            "color": color,
+        }
+        headers, data = self._requester.requestJsonAndCheck(
+            "POST",
+            self.url + "/labels",
+            input=post_parameters
+        )
+        return github.Label.Label(self._requester, headers, data, completed=True)
+
+    def create_milestone(self, title, state=github.GithubObject.NotSet, description=github.GithubObject.NotSet, due_on=github.GithubObject.NotSet):
+        """
+        :calls: `POST /repos/:owner/:repo/milestones <http://developer.github.com/v3/issues/milestones>`_
+        :param title: string
+        :param state: string
+        :param description: string
+        :param due_on: date
+        :rtype: :class:`github.Milestone.Milestone`
+        """
+        assert isinstance(title, (str, unicode)), title
+        assert state is github.GithubObject.NotSet or isinstance(state, (str, unicode)), state
+        assert description is github.GithubObject.NotSet or isinstance(description, (str, unicode)), description
+        assert due_on is github.GithubObject.NotSet or isinstance(due_on, datetime.date), due_on
+        post_parameters = {
+            "title": title,
+        }
+        if state is not github.GithubObject.NotSet:
+            post_parameters["state"] = state
+        if description is not github.GithubObject.NotSet:
+            post_parameters["description"] = description
+        if due_on is not github.GithubObject.NotSet:
+            post_parameters["due_on"] = due_on.strftime("%Y-%m-%d")
+        headers, data = self._requester.requestJsonAndCheck(
+            "POST",
+            self.url + "/milestones",
+            input=post_parameters
+        )
+        return github.Milestone.Milestone(self._requester, headers, data, completed=True)
+
+    def create_pull(self, *args, **kwds):
+        """
+        :calls: `POST /repos/:owner/:repo/pulls <http://developer.github.com/v3/pulls>`_
+        :param title: string
+        :param body: string
+        :param issue: :class:`github.Issue.Issue`
+        :param base: string
+        :param head: string
+        :rtype: :class:`github.PullRequest.PullRequest`
+        """
+        if len(args) + len(kwds) == 4:
+            return self.__create_pull_1(*args, **kwds)
+        else:
+            return self.__create_pull_2(*args, **kwds)
+
+    def __create_pull_1(self, title, body, base, head):
+        assert isinstance(title, (str, unicode)), title
+        assert isinstance(body, (str, unicode)), body
+        assert isinstance(base, (str, unicode)), base
+        assert isinstance(head, (str, unicode)), head
+        return self.__create_pull(title=title, body=body, base=base, head=head)
+
+    def __create_pull_2(self, issue, base, head):
+        assert isinstance(issue, github.Issue.Issue), issue
+        assert isinstance(base, (str, unicode)), base
+        assert isinstance(head, (str, unicode)), head
+        return self.__create_pull(issue=issue._identity, base=base, head=head)
+
+    def __create_pull(self, **kwds):
+        post_parameters = kwds
+        headers, data = self._requester.requestJsonAndCheck(
+            "POST",
+            self.url + "/pulls",
+            input=post_parameters
+        )
+        return github.PullRequest.PullRequest(self._requester, headers, data, completed=True)
+
+    def delete(self):
+        """
+        :calls: `DELETE /repos/:owner/:repo <http://developer.github.com/v3/repos>`_
+        :rtype: None
+        """
+        headers, data = self._requester.requestJsonAndCheck(
+            "DELETE",
+            self.url
+        )
+
+    def edit(self, name, description=github.GithubObject.NotSet, homepage=github.GithubObject.NotSet, private=github.GithubObject.NotSet, has_issues=github.GithubObject.NotSet, has_wiki=github.GithubObject.NotSet, has_downloads=github.GithubObject.NotSet, default_branch=github.GithubObject.NotSet):
+        """
+        :calls: `PATCH /repos/:owner/:repo <http://developer.github.com/v3/repos>`_
+        :param name: string
+        :param description: string
+        :param homepage: string
+        :param private: bool
+        :param has_issues: bool
+        :param has_wiki: bool
+        :param has_downloads: bool
+        :param default_branch: string
+        :rtype: None
+        """
+        assert isinstance(name, (str, unicode)), name
+        assert description is github.GithubObject.NotSet or isinstance(description, (str, unicode)), description
+        assert homepage is github.GithubObject.NotSet or isinstance(homepage, (str, unicode)), homepage
+        assert private is github.GithubObject.NotSet or isinstance(private, bool), private
+        assert has_issues is github.GithubObject.NotSet or isinstance(has_issues, bool), has_issues
+        assert has_wiki is github.GithubObject.NotSet or isinstance(has_wiki, bool), has_wiki
+        assert has_downloads is github.GithubObject.NotSet or isinstance(has_downloads, bool), has_downloads
+        assert default_branch is github.GithubObject.NotSet or isinstance(default_branch, (str, unicode)), default_branch
+        post_parameters = {
+            "name": name,
+        }
+        if description is not github.GithubObject.NotSet:
+            post_parameters["description"] = description
+        if homepage is not github.GithubObject.NotSet:
+            post_parameters["homepage"] = homepage
+        if private is not github.GithubObject.NotSet:
+            post_parameters["private"] = private
+        if has_issues is not github.GithubObject.NotSet:
+            post_parameters["has_issues"] = has_issues
+        if has_wiki is not github.GithubObject.NotSet:
+            post_parameters["has_wiki"] = has_wiki
+        if has_downloads is not github.GithubObject.NotSet:
+            post_parameters["has_downloads"] = has_downloads
+        if default_branch is not github.GithubObject.NotSet:
+            post_parameters["default_branch"] = default_branch
+        headers, data = self._requester.requestJsonAndCheck(
+            "PATCH",
+            self.url,
+            input=post_parameters
+        )
+        self._useAttributes(data)
+
+    def get_archive_link(self, archive_format, ref=github.GithubObject.NotSet):
+        """
+        :calls: `GET /repos/:owner/:repo/:archive_format/:ref <http://developer.github.com/v3/repos/contents>`_
+        :param archive_format: string
+        :param ref: string
+        :rtype: string
+        """
+        assert isinstance(archive_format, (str, unicode)), archive_format
+        assert ref is github.GithubObject.NotSet or isinstance(ref, (str, unicode)), ref
+        url = self.url + "/" + archive_format
+        if ref is not github.GithubObject.NotSet:
+            url += "/" + ref
+        headers, data = self._requester.requestJsonAndCheck(
+            "GET",
+            url
+        )
+        return headers["location"]
+
+    def get_assignees(self):
+        """
+        :calls: `GET /repos/:owner/:repo/assignees <http://developer.github.com/v3/issues/assignees>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.NamedUser.NamedUser`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.NamedUser.NamedUser,
+            self._requester,
+            self.url + "/assignees",
+            None
+        )
+
+    def get_branch(self, branch):
+        """
+        :calls: `GET /repos/:owner/:repo/branches/:branch <http://developer.github.com/v3/repos>`_
+        :param branch: string
+        :rtype: :class:`github.Branch.Branch`
+        """
+        assert isinstance(branch, (str, unicode)), branch
+        headers, data = self._requester.requestJsonAndCheck(
+            "GET",
+            self.url + "/branches/" + branch
+        )
+        return github.Branch.Branch(self._requester, headers, data, completed=True)
+
+    def get_branches(self):
+        """
+        :calls: `GET /repos/:owner/:repo/branches <http://developer.github.com/v3/repos>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Branch.Branch`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.Branch.Branch,
+            self._requester,
+            self.url + "/branches",
+            None
+        )
+
+    def get_collaborators(self):
+        """
+        :calls: `GET /repos/:owner/:repo/collaborators <http://developer.github.com/v3/repos/collaborators>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.NamedUser.NamedUser`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.NamedUser.NamedUser,
+            self._requester,
+            self.url + "/collaborators",
+            None
+        )
+
+    def get_comment(self, id):
+        """
+        :calls: `GET /repos/:owner/:repo/comments/:id <http://developer.github.com/v3/repos/comments>`_
+        :param id: integer
+        :rtype: :class:`github.CommitComment.CommitComment`
+        """
+        assert isinstance(id, (int, long)), id
+        headers, data = self._requester.requestJsonAndCheck(
+            "GET",
+            self.url + "/comments/" + str(id)
+        )
+        return github.CommitComment.CommitComment(self._requester, headers, data, completed=True)
+
+    def get_comments(self):
+        """
+        :calls: `GET /repos/:owner/:repo/comments <http://developer.github.com/v3/repos/comments>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.CommitComment.CommitComment`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.CommitComment.CommitComment,
+            self._requester,
+            self.url + "/comments",
+            None
+        )
+
+    def get_commit(self, sha):
+        """
+        :calls: `GET /repos/:owner/:repo/commits/:sha <http://developer.github.com/v3/repos/commits>`_
+        :param sha: string
+        :rtype: :class:`github.Commit.Commit`
+        """
+        assert isinstance(sha, (str, unicode)), sha
+        headers, data = self._requester.requestJsonAndCheck(
+            "GET",
+            self.url + "/commits/" + sha
+        )
+        return github.Commit.Commit(self._requester, headers, data, completed=True)
+
+    def get_commits(self, sha=github.GithubObject.NotSet, path=github.GithubObject.NotSet, since=github.GithubObject.NotSet, until=github.GithubObject.NotSet, author=github.GithubObject.NotSet):
+        """
+        :calls: `GET /repos/:owner/:repo/commits <http://developer.github.com/v3/repos/commits>`_
+        :param sha: string
+        :param path: string
+        :param since: datetime.datetime
+        :param until: datetime.datetime
+        :param author: string or :class:`github.NamedUser.NamedUser` or :class:`github.AuthenticatedUser.AuthenticatedUser`
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Commit.Commit`
+        """
+        assert sha is github.GithubObject.NotSet or isinstance(sha, (str, unicode)), sha
+        assert path is github.GithubObject.NotSet or isinstance(path, (str, unicode)), path
+        assert since is github.GithubObject.NotSet or isinstance(since, datetime.datetime), since
+        assert until is github.GithubObject.NotSet or isinstance(until, datetime.datetime), until
+        assert author is github.GithubObject.NotSet or isinstance(author, (str, unicode, github.NamedUser.NamedUser, github.AuthenticatedUser.AuthenticatedUser)), author
+        url_parameters = dict()
+        if sha is not github.GithubObject.NotSet:
+            url_parameters["sha"] = sha
+        if path is not github.GithubObject.NotSet:
+            url_parameters["path"] = path
+        if since is not github.GithubObject.NotSet:
+            url_parameters["since"] = since.strftime("%Y-%m-%dT%H:%M:%SZ")
+        if until is not github.GithubObject.NotSet:
+            url_parameters["until"] = until.strftime("%Y-%m-%dT%H:%M:%SZ")
+        if author is not github.GithubObject.NotSet:
+            if isinstance(author, (github.NamedUser.NamedUser, github.AuthenticatedUser.AuthenticatedUser)):
+                url_parameters["author"] = author.login
+            else:
+                url_parameters["author"] = author
+        return github.PaginatedList.PaginatedList(
+            github.Commit.Commit,
+            self._requester,
+            self.url + "/commits",
+            url_parameters
+        )
+
+    def get_contents(self, path, ref=github.GithubObject.NotSet):
+        """
+        :calls: `GET /repos/:owner/:repo/contents/:path <http://developer.github.com/v3/repos/contents>`_
+        :param path: string
+        :param ref: string
+        :rtype: :class:`github.ContentFile.ContentFile`
+        """
+        return self.get_file_contents(path, ref)
+
+    def get_file_contents(self, path, ref=github.GithubObject.NotSet):
+        """
+        :calls: `GET /repos/:owner/:repo/contents/:path <http://developer.github.com/v3/repos/contents>`_
+        :param path: string
+        :param ref: string
+        :rtype: :class:`github.ContentFile.ContentFile`
+        """
+        assert isinstance(path, (str, unicode)), path
+        assert ref is github.GithubObject.NotSet or isinstance(ref, (str, unicode)), ref
+        url_parameters = dict()
+        if ref is not github.GithubObject.NotSet:
+            url_parameters["ref"] = ref
+        headers, data = self._requester.requestJsonAndCheck(
+            "GET",
+            self.url + "/contents" + path,
+            parameters=url_parameters
+        )
+        return github.ContentFile.ContentFile(self._requester, headers, data, completed=True)
+
+    def get_dir_contents(self, path, ref=github.GithubObject.NotSet):
+        """
+        :calls: `GET /repos/:owner/:repo/contents/:path <http://developer.github.com/v3/repos/contents>`_
+        :param path: string
+        :param ref: string
+        :rtype: list of :class:`github.ContentFile.ContentFile`
+        """
+        assert isinstance(path, (str, unicode)), path
+        assert ref is github.GithubObject.NotSet or isinstance(ref, (str, unicode)), ref
+        url_parameters = dict()
+        if ref is not github.GithubObject.NotSet:
+            url_parameters["ref"] = ref
+        headers, data = self._requester.requestJsonAndCheck(
+            "GET",
+            self.url + "/contents" + path,
+            parameters=url_parameters
+        )
+
+        # Handle 302 redirect response
+        if headers.get('status') == '302 Found' and headers.get('location'):
+            headers, data = self._requester.requestJsonAndCheck(
+                "GET",
+                headers['location'],
+                parameters=url_parameters
+            )
+
+        return [
+            github.ContentFile.ContentFile(self._requester, headers, attributes, completed=(attributes["type"] != "file"))  # Lazy completion only makes sense for files. See discussion here: https://github.com/jacquev6/PyGithub/issues/140#issuecomment-13481130
+            for attributes in data
+        ]
+
+    def get_contributors(self):
+        """
+        :calls: `GET /repos/:owner/:repo/contributors <http://developer.github.com/v3/repos>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.NamedUser.NamedUser`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.NamedUser.NamedUser,
+            self._requester,
+            self.url + "/contributors",
+            None
+        )
+
+    def get_download(self, id):
+        """
+        :calls: `GET /repos/:owner/:repo/downloads/:id <http://developer.github.com/v3/repos/downloads>`_
+        :param id: integer
+        :rtype: :class:`github.Download.Download`
+        """
+        assert isinstance(id, (int, long)), id
+        headers, data = self._requester.requestJsonAndCheck(
+            "GET",
+            self.url + "/downloads/" + str(id)
+        )
+        return github.Download.Download(self._requester, headers, data, completed=True)
+
+    def get_downloads(self):
+        """
+        :calls: `GET /repos/:owner/:repo/downloads <http://developer.github.com/v3/repos/downloads>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Download.Download`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.Download.Download,
+            self._requester,
+            self.url + "/downloads",
+            None
+        )
+
+    def get_events(self):
+        """
+        :calls: `GET /repos/:owner/:repo/events <http://developer.github.com/v3/activity/events>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Event.Event`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.Event.Event,
+            self._requester,
+            self.url + "/events",
+            None
+        )
+
+    def get_forks(self):
+        """
+        :calls: `GET /repos/:owner/:repo/forks <http://developer.github.com/v3/repos/forks>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Repository.Repository`
+        """
+        return github.PaginatedList.PaginatedList(
+            Repository,
+            self._requester,
+            self.url + "/forks",
+            None
+        )
+
+    def get_git_blob(self, sha):
+        """
+        :calls: `GET /repos/:owner/:repo/git/blobs/:sha <http://developer.github.com/v3/git/blobs>`_
+        :param sha: string
+        :rtype: :class:`github.GitBlob.GitBlob`
+        """
+        assert isinstance(sha, (str, unicode)), sha
+        headers, data = self._requester.requestJsonAndCheck(
+            "GET",
+            self.url + "/git/blobs/" + sha
+        )
+        return github.GitBlob.GitBlob(self._requester, headers, data, completed=True)
+
+    def get_git_commit(self, sha):
+        """
+        :calls: `GET /repos/:owner/:repo/git/commits/:sha <http://developer.github.com/v3/git/commits>`_
+        :param sha: string
+        :rtype: :class:`github.GitCommit.GitCommit`
+        """
+        assert isinstance(sha, (str, unicode)), sha
+        headers, data = self._requester.requestJsonAndCheck(
+            "GET",
+            self.url + "/git/commits/" + sha
+        )
+        return github.GitCommit.GitCommit(self._requester, headers, data, completed=True)
+
+    def get_git_ref(self, ref):
+        """
+        :calls: `GET /repos/:owner/:repo/git/refs/:ref <http://developer.github.com/v3/git/refs>`_
+        :param ref: string
+        :rtype: :class:`github.GitRef.GitRef`
+        """
+        prefix = "/git/refs/"
+        if not self._requester.FIX_REPO_GET_GIT_REF:
+            prefix = "/git/"
+        assert isinstance(ref, (str, unicode)), ref
+        headers, data = self._requester.requestJsonAndCheck(
+            "GET",
+            self.url + prefix + ref
+        )
+        return github.GitRef.GitRef(self._requester, headers, data, completed=True)
+
+    def get_git_refs(self):
+        """
+        :calls: `GET /repos/:owner/:repo/git/refs <http://developer.github.com/v3/git/refs>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.GitRef.GitRef`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.GitRef.GitRef,
+            self._requester,
+            self.url + "/git/refs",
+            None
+        )
+
+    def get_git_tag(self, sha):
+        """
+        :calls: `GET /repos/:owner/:repo/git/tags/:sha <http://developer.github.com/v3/git/tags>`_
+        :param sha: string
+        :rtype: :class:`github.GitTag.GitTag`
+        """
+        assert isinstance(sha, (str, unicode)), sha
+        headers, data = self._requester.requestJsonAndCheck(
+            "GET",
+            self.url + "/git/tags/" + sha
+        )
+        return github.GitTag.GitTag(self._requester, headers, data, completed=True)
+
+    def get_git_tree(self, sha, recursive=github.GithubObject.NotSet):
+        """
+        :calls: `GET /repos/:owner/:repo/git/trees/:sha <http://developer.github.com/v3/git/trees>`_
+        :param sha: string
+        :param recursive: bool
+        :rtype: :class:`github.GitTree.GitTree`
+        """
+        assert isinstance(sha, (str, unicode)), sha
+        assert recursive is github.GithubObject.NotSet or isinstance(recursive, bool), recursive
+        url_parameters = dict()
+        if recursive is not github.GithubObject.NotSet:
+            url_parameters["recursive"] = recursive
+        headers, data = self._requester.requestJsonAndCheck(
+            "GET",
+            self.url + "/git/trees/" + sha,
+            parameters=url_parameters
+        )
+        return github.GitTree.GitTree(self._requester, headers, data, completed=True)
+
+    def get_hook(self, id):
+        """
+        :calls: `GET /repos/:owner/:repo/hooks/:id <http://developer.github.com/v3/repos/hooks>`_
+        :param id: integer
+        :rtype: :class:`github.Hook.Hook`
+        """
+        assert isinstance(id, (int, long)), id
+        headers, data = self._requester.requestJsonAndCheck(
+            "GET",
+            self.url + "/hooks/" + str(id)
+        )
+        return github.Hook.Hook(self._requester, headers, data, completed=True)
+
+    def get_hooks(self):
+        """
+        :calls: `GET /repos/:owner/:repo/hooks <http://developer.github.com/v3/repos/hooks>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Hook.Hook`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.Hook.Hook,
+            self._requester,
+            self.url + "/hooks",
+            None
+        )
+
+    def get_issue(self, number):
+        """
+        :calls: `GET /repos/:owner/:repo/issues/:number <http://developer.github.com/v3/issues>`_
+        :param number: integer
+        :rtype: :class:`github.Issue.Issue`
+        """
+        assert isinstance(number, (int, long)), number
+        headers, data = self._requester.requestJsonAndCheck(
+            "GET",
+            self.url + "/issues/" + str(number)
+        )
+        return github.Issue.Issue(self._requester, headers, data, completed=True)
+
+    def get_issues(self, milestone=github.GithubObject.NotSet, state=github.GithubObject.NotSet, assignee=github.GithubObject.NotSet, mentioned=github.GithubObject.NotSet, labels=github.GithubObject.NotSet, sort=github.GithubObject.NotSet, direction=github.GithubObject.NotSet, since=github.GithubObject.NotSet):
+        """
+        :calls: `GET /repos/:owner/:repo/issues <http://developer.github.com/v3/issues>`_
+        :param milestone: :class:`github.Milestone.Milestone` or "none" or "*"
+        :param state: string
+        :param assignee: string or :class:`github.NamedUser.NamedUser` or "none" or "*"
+        :param mentioned: :class:`github.NamedUser.NamedUser`
+        :param labels: list of :class:`github.Label.Label`
+        :param sort: string
+        :param direction: string
+        :param since: datetime.datetime
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Issue.Issue`
+        """
+        assert milestone is github.GithubObject.NotSet or milestone == "*" or milestone == "none" or isinstance(milestone, github.Milestone.Milestone), milestone
+        assert state is github.GithubObject.NotSet or isinstance(state, (str, unicode)), state
+        assert assignee is github.GithubObject.NotSet or isinstance(assignee, github.NamedUser.NamedUser) or isinstance(assignee, (str, unicode)), assignee
+        assert mentioned is github.GithubObject.NotSet or isinstance(mentioned, github.NamedUser.NamedUser), mentioned
+        assert labels is github.GithubObject.NotSet or all(isinstance(element, github.Label.Label) for element in labels), labels
+        assert sort is github.GithubObject.NotSet or isinstance(sort, (str, unicode)), sort
+        assert direction is github.GithubObject.NotSet or isinstance(direction, (str, unicode)), direction
+        assert since is github.GithubObject.NotSet or isinstance(since, datetime.datetime), since
+        url_parameters = dict()
+        if milestone is not github.GithubObject.NotSet:
+            if isinstance(milestone, str):
+                url_parameters["milestone"] = milestone
+            else:
+                url_parameters["milestone"] = milestone._identity
+        if state is not github.GithubObject.NotSet:
+            url_parameters["state"] = state
+        if assignee is not github.GithubObject.NotSet:
+            if isinstance(assignee, str):
+                url_parameters["assignee"] = assignee
+            else:
+                url_parameters["assignee"] = assignee._identity
+        if mentioned is not github.GithubObject.NotSet:
+            url_parameters["mentioned"] = mentioned._identity
+        if labels is not github.GithubObject.NotSet:
+            url_parameters["labels"] = ",".join(label.name for label in labels)
+        if sort is not github.GithubObject.NotSet:
+            url_parameters["sort"] = sort
+        if direction is not github.GithubObject.NotSet:
+            url_parameters["direction"] = direction
+        if since is not github.GithubObject.NotSet:
+            url_parameters["since"] = since.strftime("%Y-%m-%dT%H:%M:%SZ")
+        return github.PaginatedList.PaginatedList(
+            github.Issue.Issue,
+            self._requester,
+            self.url + "/issues",
+            url_parameters
+        )
+
+    def get_issues_comments(self, sort=github.GithubObject.NotSet, direction=github.GithubObject.NotSet, since=github.GithubObject.NotSet):
+        """
+        :calls: `GET /repos/:owner/:repo/issues/comments <http://developer.github.com/v3/issues/comments>`_
+        :param sort: string
+        :param direction: string
+        :param since: datetime.datetime
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.IssueComment.IssueComment`
+        """
+        assert sort is github.GithubObject.NotSet or isinstance(sort, (str, unicode)), sort
+        assert direction is github.GithubObject.NotSet or isinstance(direction, (str, unicode)), direction
+        assert since is github.GithubObject.NotSet or isinstance(since, datetime.datetime), since
+        url_parameters = dict()
+        if sort is not github.GithubObject.NotSet:
+            url_parameters["sort"] = sort
+        if direction is not github.GithubObject.NotSet:
+            url_parameters["direction"] = direction
+        if since is not github.GithubObject.NotSet:
+            url_parameters["since"] = since.strftime("%Y-%m-%dT%H:%M:%SZ")
+        return github.PaginatedList.PaginatedList(
+            github.IssueComment.IssueComment,
+            self._requester,
+            self.url + "/issues/comments",
+            url_parameters
+        )
+
+    def get_issues_event(self, id):
+        """
+        :calls: `GET /repos/:owner/:repo/issues/events/:id <http://developer.github.com/v3/issues/events>`_
+        :param id: integer
+        :rtype: :class:`github.IssueEvent.IssueEvent`
+        """
+        assert isinstance(id, (int, long)), id
+        headers, data = self._requester.requestJsonAndCheck(
+            "GET",
+            self.url + "/issues/events/" + str(id)
+        )
+        return github.IssueEvent.IssueEvent(self._requester, headers, data, completed=True)
+
+    def get_issues_events(self):
+        """
+        :calls: `GET /repos/:owner/:repo/issues/events <http://developer.github.com/v3/issues/events>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.IssueEvent.IssueEvent`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.IssueEvent.IssueEvent,
+            self._requester,
+            self.url + "/issues/events",
+            None
+        )
+
+    def get_key(self, id):
+        """
+        :calls: `GET /repos/:owner/:repo/keys/:id <http://developer.github.com/v3/repos/keys>`_
+        :param id: integer
+        :rtype: :class:`github.RepositoryKey.RepositoryKey`
+        """
+        assert isinstance(id, (int, long)), id
+        headers, data = self._requester.requestJsonAndCheck(
+            "GET",
+            self.url + "/keys/" + str(id)
+        )
+        return github.RepositoryKey.RepositoryKey(self._requester, headers, data, completed=True, repoUrl=self.url)
+
+    def get_keys(self):
+        """
+        :calls: `GET /repos/:owner/:repo/keys <http://developer.github.com/v3/repos/keys>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.RepositoryKey.RepositoryKey`
+        """
+        return github.PaginatedList.PaginatedList(
+            lambda requester, headers, data, completed: github.RepositoryKey.RepositoryKey(requester, headers, data, completed, repoUrl=self.url),
+            self._requester,
+            self.url + "/keys",
+            None
+        )
+
+    def get_label(self, name):
+        """
+        :calls: `GET /repos/:owner/:repo/labels/:name <http://developer.github.com/v3/issues/labels>`_
+        :param name: string
+        :rtype: :class:`github.Label.Label`
+        """
+        assert isinstance(name, (str, unicode)), name
+        headers, data = self._requester.requestJsonAndCheck(
+            "GET",
+            self.url + "/labels/" + urllib.quote(name)
+        )
+        return github.Label.Label(self._requester, headers, data, completed=True)
+
+    def get_labels(self):
+        """
+        :calls: `GET /repos/:owner/:repo/labels <http://developer.github.com/v3/issues/labels>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Label.Label`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.Label.Label,
+            self._requester,
+            self.url + "/labels",
+            None
+        )
+
+    def get_languages(self):
+        """
+        :calls: `GET /repos/:owner/:repo/languages <http://developer.github.com/v3/repos>`_
+        :rtype: dict of string to integer
+        """
+        headers, data = self._requester.requestJsonAndCheck(
+            "GET",
+            self.url + "/languages"
+        )
+        return data
+
+    def get_milestone(self, number):
+        """
+        :calls: `GET /repos/:owner/:repo/milestones/:number <http://developer.github.com/v3/issues/milestones>`_
+        :param number: integer
+        :rtype: :class:`github.Milestone.Milestone`
+        """
+        assert isinstance(number, (int, long)), number
+        headers, data = self._requester.requestJsonAndCheck(
+            "GET",
+            self.url + "/milestones/" + str(number)
+        )
+        return github.Milestone.Milestone(self._requester, headers, data, completed=True)
+
+    def get_milestones(self, state=github.GithubObject.NotSet, sort=github.GithubObject.NotSet, direction=github.GithubObject.NotSet):
+        """
+        :calls: `GET /repos/:owner/:repo/milestones <http://developer.github.com/v3/issues/milestones>`_
+        :param state: string
+        :param sort: string
+        :param direction: string
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Milestone.Milestone`
+        """
+        assert state is github.GithubObject.NotSet or isinstance(state, (str, unicode)), state
+        assert sort is github.GithubObject.NotSet or isinstance(sort, (str, unicode)), sort
+        assert direction is github.GithubObject.NotSet or isinstance(direction, (str, unicode)), direction
+        url_parameters = dict()
+        if state is not github.GithubObject.NotSet:
+            url_parameters["state"] = state
+        if sort is not github.GithubObject.NotSet:
+            url_parameters["sort"] = sort
+        if direction is not github.GithubObject.NotSet:
+            url_parameters["direction"] = direction
+        return github.PaginatedList.PaginatedList(
+            github.Milestone.Milestone,
+            self._requester,
+            self.url + "/milestones",
+            url_parameters
+        )
+
+    def get_network_events(self):
+        """
+        :calls: `GET /networks/:owner/:repo/events <http://developer.github.com/v3/activity/events>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Event.Event`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.Event.Event,
+            self._requester,
+            "/networks/" + self.owner.login + "/" + self.name + "/events",
+            None
+        )
+
+    def get_pull(self, number):
+        """
+        :calls: `GET /repos/:owner/:repo/pulls/:number <http://developer.github.com/v3/pulls>`_
+        :param number: integer
+        :rtype: :class:`github.PullRequest.PullRequest`
+        """
+        assert isinstance(number, (int, long)), number
+        headers, data = self._requester.requestJsonAndCheck(
+            "GET",
+            self.url + "/pulls/" + str(number)
+        )
+        return github.PullRequest.PullRequest(self._requester, headers, data, completed=True)
+
+    def get_pulls(self, state=github.GithubObject.NotSet, sort=github.GithubObject.NotSet):
+        """
+        :calls: `GET /repos/:owner/:repo/pulls <http://developer.github.com/v3/pulls>`_
+        :param state: string
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.PullRequest.PullRequest`
+        """
+        assert state is github.GithubObject.NotSet or isinstance(state, (str, unicode)), state
+        assert sort is github.GithubObject.NotSet or isinstance(sort, (str, unicode)), sort
+        url_parameters = dict()
+        if state is not github.GithubObject.NotSet:
+            url_parameters["state"] = state
+        if sort is not github.GithubObject.NotSet:
+            url_parameters["sort"] = sort
+        return github.PaginatedList.PaginatedList(
+            github.PullRequest.PullRequest,
+            self._requester,
+            self.url + "/pulls",
+            url_parameters
+        )
+
+    def get_pulls_comments(self, sort=github.GithubObject.NotSet, direction=github.GithubObject.NotSet, since=github.GithubObject.NotSet):
+        """
+        :calls: `GET /repos/:owner/:repo/pulls/comments <http://developer.github.com/v3/pulls/comments>`_
+        :param sort: string
+        :param direction: string
+        :param since: datetime.datetime
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.PullRequestComment.PullRequestComment`
+        """
+        return self.get_pulls_review_comments(sort, direction, since)
+
+    def get_pulls_review_comments(self, sort=github.GithubObject.NotSet, direction=github.GithubObject.NotSet, since=github.GithubObject.NotSet):
+        """
+        :calls: `GET /repos/:owner/:repo/pulls/comments <http://developer.github.com/v3/pulls/comments>`_
+        :param sort: string
+        :param direction: string
+        :param since: datetime.datetime
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.PullRequestComment.PullRequestComment`
+        """
+        assert sort is github.GithubObject.NotSet or isinstance(sort, (str, unicode)), sort
+        assert direction is github.GithubObject.NotSet or isinstance(direction, (str, unicode)), direction
+        assert since is github.GithubObject.NotSet or isinstance(since, datetime.datetime), since
+        url_parameters = dict()
+        if sort is not github.GithubObject.NotSet:
+            url_parameters["sort"] = sort
+        if direction is not github.GithubObject.NotSet:
+            url_parameters["direction"] = direction
+        if since is not github.GithubObject.NotSet:
+            url_parameters["since"] = since.strftime("%Y-%m-%dT%H:%M:%SZ")
+        return github.PaginatedList.PaginatedList(
+            github.IssueComment.IssueComment,
+            self._requester,
+            self.url + "/pulls/comments",
+            url_parameters
+        )
+
+    def get_readme(self, ref=github.GithubObject.NotSet):
+        """
+        :calls: `GET /repos/:owner/:repo/readme <http://developer.github.com/v3/repos/contents>`_
+        :param ref: string
+        :rtype: :class:`github.ContentFile.ContentFile`
+        """
+        assert ref is github.GithubObject.NotSet or isinstance(ref, (str, unicode)), ref
+        url_parameters = dict()
+        if ref is not github.GithubObject.NotSet:
+            url_parameters["ref"] = ref
+        headers, data = self._requester.requestJsonAndCheck(
+            "GET",
+            self.url + "/readme",
+            parameters=url_parameters
+        )
+        return github.ContentFile.ContentFile(self._requester, headers, data, completed=True)
+
+    def get_stargazers(self):
+        """
+        :calls: `GET /repos/:owner/:repo/stargazers <http://developer.github.com/v3/activity/starring>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.NamedUser.NamedUser`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.NamedUser.NamedUser,
+            self._requester,
+            self.url + "/stargazers",
+            None
+        )
+
+    def get_stargazers_with_dates(self):
+        """
+        :calls: `GET /repos/:owner/:repo/stargazers <http://developer.github.com/v3/activity/starring>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Stargazer.Stargazer`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.Stargazer.Stargazer,
+            self._requester,
+            self.url + "/stargazers",
+            None,
+            headers={'Accept': 'application/vnd.github.v3.star+json'}
+        )
+
+    def get_stats_contributors(self):
+        """
+        :calls: `GET /repos/:owner/:repo/stats/contributors <http://developer.github.com/v3/repos/statistics/#get-contributors-list-with-additions-deletions-and-commit-counts>`_
+        :rtype: None or list of :class:`github.StatsContributor.StatsContributor`
+        """
+        headers, data = self._requester.requestJsonAndCheck(
+            "GET",
+            self.url + "/stats/contributors"
+        )
+        if data == {}:
+            return None
+        else:
+            return [
+                github.StatsContributor.StatsContributor(self._requester, headers, attributes, completed=True)
+                for attributes in data
+            ]
+
+    def get_stats_commit_activity(self):
+        """
+        :calls: `GET /repos/:owner/:repo/stats/commit_activity <developer.github.com/v3/repos/statistics/#get-the-number-of-commits-per-hour-in-each-day>`_
+        :rtype: None or list of :class:`github.StatsCommitActivity.StatsCommitActivity`
+        """
+        headers, data = self._requester.requestJsonAndCheck(
+            "GET",
+            self.url + "/stats/commit_activity"
+        )
+        if data == {}:
+            return None
+        else:
+            return [
+                github.StatsCommitActivity.StatsCommitActivity(self._requester, headers, attributes, completed=True)
+                for attributes in data
+            ]
+
+    def get_stats_code_frequency(self):
+        """
+        :calls: `GET /repos/:owner/:repo/stats/code_frequency <http://developer.github.com/v3/repos/statistics/#get-the-number-of-additions-and-deletions-per-week>`_
+        :rtype: None or list of :class:`github.StatsCodeFrequency.StatsCodeFrequency`
+        """
+        headers, data = self._requester.requestJsonAndCheck(
+            "GET",
+            self.url + "/stats/code_frequency"
+        )
+        if data == {}:
+            return None
+        else:
+            return [
+                github.StatsCodeFrequency.StatsCodeFrequency(self._requester, headers, attributes, completed=True)
+                for attributes in data
+            ]
+
+    def get_stats_participation(self):
+        """
+        :calls: `GET /repos/:owner/:repo/stats/participation <http://developer.github.com/v3/repos/statistics/#get-the-weekly-commit-count-for-the-repo-owner-and-everyone-else>`_
+        :rtype: None or :class:`github.StatsParticipation.StatsParticipation`
+        """
+        headers, data = self._requester.requestJsonAndCheck(
+            "GET",
+            self.url + "/stats/participation"
+        )
+        if data == {}:
+            return None
+        else:
+            return github.StatsParticipation.StatsParticipation(self._requester, headers, data, completed=True)
+
+    def get_stats_punch_card(self):
+        """
+        :calls: `GET /repos/:owner/:repo/stats/punch_card <http://developer.github.com/v3/repos/statistics/#get-the-number-of-commits-per-hour-in-each-day>`_
+        :rtype: None or :class:`github.StatsPunchCard.StatsPunchCard`
+        """
+        headers, data = self._requester.requestJsonAndCheck(
+            "GET",
+            self.url + "/stats/punch_card"
+        )
+        if data == {}:
+            return None
+        else:
+            return github.StatsPunchCard.StatsPunchCard(self._requester, headers, data, completed=True)
+
+    def get_subscribers(self):
+        """
+        :calls: `GET /repos/:owner/:repo/subscribers <http://developer.github.com/v3/activity/watching>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.NamedUser.NamedUser`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.NamedUser.NamedUser,
+            self._requester,
+            self.url + "/subscribers",
+            None
+        )
+
+    def get_tags(self):
+        """
+        :calls: `GET /repos/:owner/:repo/tags <http://developer.github.com/v3/repos>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Tag.Tag`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.Tag.Tag,
+            self._requester,
+            self.url + "/tags",
+            None
+        )
+
+    def get_releases(self):
+        """
+        :calls: `GET /repos/:owner/:repo/releases <http://developer.github.com/v3/repos>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Tag.Tag`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.GitRelease.GitRelease,
+            self._requester,
+            self.url + "/releases",
+            None
+        )
+
+    def get_release(self, id):
+        """
+        :calls: `GET /repos/:owner/:repo/releases/:id https://developer.github.com/v3/repos/releases/#get-a-single-release
+        :param id: int (release id), str (tag name)
+        :rtype: None or :class:`github.GitRelease.GitRelease`
+        """
+        if isinstance(id, int):
+            headers, data = self._requester.requestJsonAndCheck(
+                "GET",
+                self.url + "/releases/" + str(id)
+            )
+            return github.GitRelease.GitRelease(self._requester, headers, data, completed=True)
+        elif isinstance(id, str):
+            headers, data = self._requester.requestJsonAndCheck(
+                "GET",
+                self.url + "/releases/tags/" + id
+            )
+            return github.GitRelease.GitRelease(self._requester, headers, data, completed=True)
+
+    def get_teams(self):
+        """
+        :calls: `GET /repos/:owner/:repo/teams <http://developer.github.com/v3/repos>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Team.Team`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.Team.Team,
+            self._requester,
+            self.url + "/teams",
+            None
+        )
+
+    def get_watchers(self):
+        """
+        :calls: `GET /repos/:owner/:repo/watchers <http://developer.github.com/v3/activity/starring>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.NamedUser.NamedUser`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.NamedUser.NamedUser,
+            self._requester,
+            self.url + "/watchers",
+            None
+        )
+
+    def has_in_assignees(self, assignee):
+        """
+        :calls: `GET /repos/:owner/:repo/assignees/:assignee <http://developer.github.com/v3/issues/assignees>`_
+        :param assignee: string or :class:`github.NamedUser.NamedUser`
+        :rtype: bool
+        """
+        assert isinstance(assignee, github.NamedUser.NamedUser) or isinstance(assignee, (str, unicode)), assignee
+
+        if isinstance(assignee, github.NamedUser.NamedUser):
+            assignee = assignee._identity
+
+        status, headers, data = self._requester.requestJson(
+            "GET",
+            self.url + "/assignees/" + assignee
+        )
+        return status == 204
+
+    def has_in_collaborators(self, collaborator):
+        """
+        :calls: `GET /repos/:owner/:repo/collaborators/:user <http://developer.github.com/v3/repos/collaborators>`_
+        :param collaborator: string or :class:`github.NamedUser.NamedUser`
+        :rtype: bool
+        """
+        assert isinstance(collaborator, github.NamedUser.NamedUser) or isinstance(collaborator, (str, unicode)), collaborator
+
+        if isinstance(collaborator, github.NamedUser.NamedUser):
+            collaborator = collaborator._identity
+
+        status, headers, data = self._requester.requestJson(
+            "GET",
+            self.url + "/collaborators/" + collaborator
+        )
+        return status == 204
+
+    def legacy_search_issues(self, state, keyword):
+        """
+        :calls: `GET /legacy/issues/search/:owner/:repository/:state/:keyword <http://developer.github.com/v3/search/legacy>`_
+        :param state: "open" or "closed"
+        :param keyword: string
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Issue.Issue`
+        """
+        assert state in ["open", "closed"], state
+        assert isinstance(keyword, (str, unicode)), keyword
+        headers, data = self._requester.requestJsonAndCheck(
+            "GET",
+            "/legacy/issues/search/" + self.owner.login + "/" + self.name + "/" + state + "/" + urllib.quote(keyword)
+        )
+        return [
+            github.Issue.Issue(self._requester, headers, github.Legacy.convertIssue(element), completed=False)
+            for element in data["issues"]
+        ]
+
+    def merge(self, base, head, commit_message=github.GithubObject.NotSet):
+        """
+        :calls: `POST /repos/:owner/:repo/merges <http://developer.github.com/v3/repos/merging>`_
+        :param base: string
+        :param head: string
+        :param commit_message: string
+        :rtype: :class:`github.Commit.Commit`
+        """
+        assert isinstance(base, (str, unicode)), base
+        assert isinstance(head, (str, unicode)), head
+        assert commit_message is github.GithubObject.NotSet or isinstance(commit_message, (str, unicode)), commit_message
+        post_parameters = {
+            "base": base,
+            "head": head,
+        }
+        if commit_message is not github.GithubObject.NotSet:
+            post_parameters["commit_message"] = commit_message
+        headers, data = self._requester.requestJsonAndCheck(
+            "POST",
+            self.url + "/merges",
+            input=post_parameters
+        )
+        if data is None:
+            return None
+        else:
+            return github.Commit.Commit(self._requester, headers, data, completed=True)
+
+    def remove_from_collaborators(self, collaborator):
+        """
+        :calls: `DELETE /repos/:owner/:repo/collaborators/:user <http://developer.github.com/v3/repos/collaborators>`_
+        :param collaborator: string or :class:`github.NamedUser.NamedUser`
+        :rtype: None
+        """
+        assert isinstance(collaborator, github.NamedUser.NamedUser) or isinstance(collaborator, (str, unicode)), collaborator
+
+        if isinstance(collaborator, github.NamedUser.NamedUser):
+            collaborator = collaborator._identity
+
+        headers, data = self._requester.requestJsonAndCheck(
+            "DELETE",
+            self.url + "/collaborators/" + collaborator
+        )
+
+    def subscribe_to_hub(self, event, callback, secret=github.GithubObject.NotSet):
+        """
+        :calls: `POST /hub <http://developer.github.com/>`_
+        :param event: string
+        :param callback: string
+        :param secret: string
+        :rtype: None
+        """
+        return self._hub("subscribe", event, callback, secret)
+
+    def unsubscribe_from_hub(self, event, callback):
+        """
+        :calls: `POST /hub <http://developer.github.com/>`_
+        :param event: string
+        :param callback: string
+        :param secret: string
+        :rtype: None
+        """
+        return self._hub("unsubscribe", event, callback, github.GithubObject.NotSet)
+
+    def _hub(self, mode, event, callback, secret):
+        assert isinstance(mode, (str, unicode)), mode
+        assert isinstance(event, (str, unicode)), event
+        assert isinstance(callback, (str, unicode)), callback
+        assert secret is github.GithubObject.NotSet or isinstance(secret, (str, unicode)), secret
+
+        post_parameters = {
+            "hub.mode": mode,
+            "hub.topic": "https://github.com/" + self.full_name + "/events/" + event,
+            "hub.callback": callback,
+        }
+        if secret is not github.GithubObject.NotSet:
+            post_parameters["hub.secret"] = secret
+
+        headers, output = self._requester.requestMultipartAndCheck(
+            "POST",
+            "/hub",
+            input=post_parameters
+        )
+
+    @property
+    def _identity(self):
+        return self.owner.login + "/" + self.name
+
+    def _initAttributes(self):
+        self._archive_url = github.GithubObject.NotSet
+        self._assignees_url = github.GithubObject.NotSet
+        self._blobs_url = github.GithubObject.NotSet
+        self._branches_url = github.GithubObject.NotSet
+        self._clone_url = github.GithubObject.NotSet
+        self._collaborators_url = github.GithubObject.NotSet
+        self._comments_url = github.GithubObject.NotSet
+        self._commits_url = github.GithubObject.NotSet
+        self._compare_url = github.GithubObject.NotSet
+        self._contents_url = github.GithubObject.NotSet
+        self._contributors_url = github.GithubObject.NotSet
+        self._created_at = github.GithubObject.NotSet
+        self._default_branch = github.GithubObject.NotSet
+        self._description = github.GithubObject.NotSet
+        self._downloads_url = github.GithubObject.NotSet
+        self._events_url = github.GithubObject.NotSet
+        self._fork = github.GithubObject.NotSet
+        self._forks = github.GithubObject.NotSet
+        self._forks_count = github.GithubObject.NotSet
+        self._forks_url = github.GithubObject.NotSet
+        self._full_name = github.GithubObject.NotSet
+        self._git_commits_url = github.GithubObject.NotSet
+        self._git_refs_url = github.GithubObject.NotSet
+        self._git_tags_url = github.GithubObject.NotSet
+        self._git_url = github.GithubObject.NotSet
+        self._has_downloads = github.GithubObject.NotSet
+        self._has_issues = github.GithubObject.NotSet
+        self._has_wiki = github.GithubObject.NotSet
+        self._homepage = github.GithubObject.NotSet
+        self._hooks_url = github.GithubObject.NotSet
+        self._html_url = github.GithubObject.NotSet
+        self._id = github.GithubObject.NotSet
+        self._issue_comment_url = github.GithubObject.NotSet
+        self._issue_events_url = github.GithubObject.NotSet
+        self._issues_url = github.GithubObject.NotSet
+        self._keys_url = github.GithubObject.NotSet
+        self._labels_url = github.GithubObject.NotSet
+        self._language = github.GithubObject.NotSet
+        self._languages_url = github.GithubObject.NotSet
+        self._master_branch = github.GithubObject.NotSet
+        self._merges_url = github.GithubObject.NotSet
+        self._milestones_url = github.GithubObject.NotSet
+        self._mirror_url = github.GithubObject.NotSet
+        self._name = github.GithubObject.NotSet
+        self._network_count = github.GithubObject.NotSet
+        self._notifications_url = github.GithubObject.NotSet
+        self._open_issues = github.GithubObject.NotSet
+        self._open_issues_count = github.GithubObject.NotSet
+        self._organization = github.GithubObject.NotSet
+        self._owner = github.GithubObject.NotSet
+        self._parent = github.GithubObject.NotSet
+        self._permissions = github.GithubObject.NotSet
+        self._private = github.GithubObject.NotSet
+        self._pulls_url = github.GithubObject.NotSet
+        self._pushed_at = github.GithubObject.NotSet
+        self._size = github.GithubObject.NotSet
+        self._source = github.GithubObject.NotSet
+        self._ssh_url = github.GithubObject.NotSet
+        self._stargazers_count = github.GithubObject.NotSet
+        self._stargazers_url = github.GithubObject.NotSet
+        self._statuses_url = github.GithubObject.NotSet
+        self._subscribers_url = github.GithubObject.NotSet
+        self._subscription_url = github.GithubObject.NotSet
+        self._svn_url = github.GithubObject.NotSet
+        self._tags_url = github.GithubObject.NotSet
+        self._teams_url = github.GithubObject.NotSet
+        self._trees_url = github.GithubObject.NotSet
+        self._updated_at = github.GithubObject.NotSet
+        self._url = github.GithubObject.NotSet
+        self._watchers = github.GithubObject.NotSet
+        self._watchers_count = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "archive_url" in attributes:  # pragma no branch
+            self._archive_url = self._makeStringAttribute(attributes["archive_url"])
+        if "assignees_url" in attributes:  # pragma no branch
+            self._assignees_url = self._makeStringAttribute(attributes["assignees_url"])
+        if "blobs_url" in attributes:  # pragma no branch
+            self._blobs_url = self._makeStringAttribute(attributes["blobs_url"])
+        if "branches_url" in attributes:  # pragma no branch
+            self._branches_url = self._makeStringAttribute(attributes["branches_url"])
+        if "clone_url" in attributes:  # pragma no branch
+            self._clone_url = self._makeStringAttribute(attributes["clone_url"])
+        if "collaborators_url" in attributes:  # pragma no branch
+            self._collaborators_url = self._makeStringAttribute(attributes["collaborators_url"])
+        if "comments_url" in attributes:  # pragma no branch
+            self._comments_url = self._makeStringAttribute(attributes["comments_url"])
+        if "commits_url" in attributes:  # pragma no branch
+            self._commits_url = self._makeStringAttribute(attributes["commits_url"])
+        if "compare_url" in attributes:  # pragma no branch
+            self._compare_url = self._makeStringAttribute(attributes["compare_url"])
+        if "contents_url" in attributes:  # pragma no branch
+            self._contents_url = self._makeStringAttribute(attributes["contents_url"])
+        if "contributors_url" in attributes:  # pragma no branch
+            self._contributors_url = self._makeStringAttribute(attributes["contributors_url"])
+        if "created_at" in attributes:  # pragma no branch
+            self._created_at = self._makeDatetimeAttribute(attributes["created_at"])
+        if "default_branch" in attributes:  # pragma no branch
+            self._default_branch = self._makeStringAttribute(attributes["default_branch"])
+        if "description" in attributes:  # pragma no branch
+            self._description = self._makeStringAttribute(attributes["description"])
+        if "downloads_url" in attributes:  # pragma no branch
+            self._downloads_url = self._makeStringAttribute(attributes["downloads_url"])
+        if "events_url" in attributes:  # pragma no branch
+            self._events_url = self._makeStringAttribute(attributes["events_url"])
+        if "fork" in attributes:  # pragma no branch
+            self._fork = self._makeBoolAttribute(attributes["fork"])
+        if "forks" in attributes:  # pragma no branch
+            self._forks = self._makeIntAttribute(attributes["forks"])
+        if "forks_count" in attributes:  # pragma no branch
+            self._forks_count = self._makeIntAttribute(attributes["forks_count"])
+        if "forks_url" in attributes:  # pragma no branch
+            self._forks_url = self._makeStringAttribute(attributes["forks_url"])
+        if "full_name" in attributes:  # pragma no branch
+            self._full_name = self._makeStringAttribute(attributes["full_name"])
+        if "git_commits_url" in attributes:  # pragma no branch
+            self._git_commits_url = self._makeStringAttribute(attributes["git_commits_url"])
+        if "git_refs_url" in attributes:  # pragma no branch
+            self._git_refs_url = self._makeStringAttribute(attributes["git_refs_url"])
+        if "git_tags_url" in attributes:  # pragma no branch
+            self._git_tags_url = self._makeStringAttribute(attributes["git_tags_url"])
+        if "git_url" in attributes:  # pragma no branch
+            self._git_url = self._makeStringAttribute(attributes["git_url"])
+        if "has_downloads" in attributes:  # pragma no branch
+            self._has_downloads = self._makeBoolAttribute(attributes["has_downloads"])
+        if "has_issues" in attributes:  # pragma no branch
+            self._has_issues = self._makeBoolAttribute(attributes["has_issues"])
+        if "has_wiki" in attributes:  # pragma no branch
+            self._has_wiki = self._makeBoolAttribute(attributes["has_wiki"])
+        if "homepage" in attributes:  # pragma no branch
+            self._homepage = self._makeStringAttribute(attributes["homepage"])
+        if "hooks_url" in attributes:  # pragma no branch
+            self._hooks_url = self._makeStringAttribute(attributes["hooks_url"])
+        if "html_url" in attributes:  # pragma no branch
+            self._html_url = self._makeStringAttribute(attributes["html_url"])
+        if "id" in attributes:  # pragma no branch
+            self._id = self._makeIntAttribute(attributes["id"])
+        if "issue_comment_url" in attributes:  # pragma no branch
+            self._issue_comment_url = self._makeStringAttribute(attributes["issue_comment_url"])
+        if "issue_events_url" in attributes:  # pragma no branch
+            self._issue_events_url = self._makeStringAttribute(attributes["issue_events_url"])
+        if "issues_url" in attributes:  # pragma no branch
+            self._issues_url = self._makeStringAttribute(attributes["issues_url"])
+        if "keys_url" in attributes:  # pragma no branch
+            self._keys_url = self._makeStringAttribute(attributes["keys_url"])
+        if "labels_url" in attributes:  # pragma no branch
+            self._labels_url = self._makeStringAttribute(attributes["labels_url"])
+        if "language" in attributes:  # pragma no branch
+            self._language = self._makeStringAttribute(attributes["language"])
+        if "languages_url" in attributes:  # pragma no branch
+            self._languages_url = self._makeStringAttribute(attributes["languages_url"])
+        if "master_branch" in attributes:  # pragma no branch
+            self._master_branch = self._makeStringAttribute(attributes["master_branch"])
+        if "merges_url" in attributes:  # pragma no branch
+            self._merges_url = self._makeStringAttribute(attributes["merges_url"])
+        if "milestones_url" in attributes:  # pragma no branch
+            self._milestones_url = self._makeStringAttribute(attributes["milestones_url"])
+        if "mirror_url" in attributes:  # pragma no branch
+            self._mirror_url = self._makeStringAttribute(attributes["mirror_url"])
+        if "name" in attributes:  # pragma no branch
+            self._name = self._makeStringAttribute(attributes["name"])
+        if "network_count" in attributes:  # pragma no branch
+            self._network_count = self._makeIntAttribute(attributes["network_count"])
+        if "notifications_url" in attributes:  # pragma no branch
+            self._notifications_url = self._makeStringAttribute(attributes["notifications_url"])
+        if "open_issues" in attributes:  # pragma no branch
+            self._open_issues = self._makeIntAttribute(attributes["open_issues"])
+        if "open_issues_count" in attributes:  # pragma no branch
+            self._open_issues_count = self._makeIntAttribute(attributes["open_issues_count"])
+        if "organization" in attributes:  # pragma no branch
+            self._organization = self._makeClassAttribute(github.Organization.Organization, attributes["organization"])
+        if "owner" in attributes:  # pragma no branch
+            self._owner = self._makeClassAttribute(github.NamedUser.NamedUser, attributes["owner"])
+        if "parent" in attributes:  # pragma no branch
+            self._parent = self._makeClassAttribute(Repository, attributes["parent"])
+        if "permissions" in attributes:  # pragma no branch
+            self._permissions = self._makeClassAttribute(github.Permissions.Permissions, attributes["permissions"])
+        if "private" in attributes:  # pragma no branch
+            self._private = self._makeBoolAttribute(attributes["private"])
+        if "pulls_url" in attributes:  # pragma no branch
+            self._pulls_url = self._makeStringAttribute(attributes["pulls_url"])
+        if "pushed_at" in attributes:  # pragma no branch
+            self._pushed_at = self._makeDatetimeAttribute(attributes["pushed_at"])
+        if "size" in attributes:  # pragma no branch
+            self._size = self._makeIntAttribute(attributes["size"])
+        if "source" in attributes:  # pragma no branch
+            self._source = self._makeClassAttribute(Repository, attributes["source"])
+        if "ssh_url" in attributes:  # pragma no branch
+            self._ssh_url = self._makeStringAttribute(attributes["ssh_url"])
+        if "stargazers_count" in attributes:  # pragma no branch
+            self._stargazers_count = self._makeIntAttribute(attributes["stargazers_count"])
+        if "stargazers_url" in attributes:  # pragma no branch
+            self._stargazers_url = self._makeStringAttribute(attributes["stargazers_url"])
+        if "statuses_url" in attributes:  # pragma no branch
+            self._statuses_url = self._makeStringAttribute(attributes["statuses_url"])
+        if "subscribers_url" in attributes:  # pragma no branch
+            self._subscribers_url = self._makeStringAttribute(attributes["subscribers_url"])
+        if "subscription_url" in attributes:  # pragma no branch
+            self._subscription_url = self._makeStringAttribute(attributes["subscription_url"])
+        if "svn_url" in attributes:  # pragma no branch
+            self._svn_url = self._makeStringAttribute(attributes["svn_url"])
+        if "tags_url" in attributes:  # pragma no branch
+            self._tags_url = self._makeStringAttribute(attributes["tags_url"])
+        if "teams_url" in attributes:  # pragma no branch
+            self._teams_url = self._makeStringAttribute(attributes["teams_url"])
+        if "trees_url" in attributes:  # pragma no branch
+            self._trees_url = self._makeStringAttribute(attributes["trees_url"])
+        if "updated_at" in attributes:  # pragma no branch
+            self._updated_at = self._makeDatetimeAttribute(attributes["updated_at"])
+        if "url" in attributes:  # pragma no branch
+            self._url = self._makeStringAttribute(attributes["url"])
+        if "watchers" in attributes:  # pragma no branch
+            self._watchers = self._makeIntAttribute(attributes["watchers"])
+        if "watchers_count" in attributes:  # pragma no branch
+            self._watchers_count = self._makeIntAttribute(attributes["watchers_count"])

--- a/github/RepositoryKey.py
+++ b/github/RepositoryKey.py
@@ -1,0 +1,133 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Srijan Choudhary <srijan4@gmail.com>                          #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2013 martinqt <m.ki2@laposte.net>                                  #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+
+
+class RepositoryKey(github.GithubObject.CompletableGithubObject):
+    """
+    This class represents RepositoryKeys. The reference can be found here http://developer.github.com/v3/repos/keys/
+    """
+
+    def __init__(self, requester, headers, attributes, completed, repoUrl):
+        github.GithubObject.CompletableGithubObject.__init__(self, requester, headers, attributes, completed)
+        self.__repoUrl = repoUrl
+
+    @property
+    def __customUrl(self):
+        return self.__repoUrl + "/keys/" + str(self.id)
+
+    @property
+    def id(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._id)
+        return self._id.value
+
+    @property
+    def key(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._key)
+        return self._key.value
+
+    @property
+    def title(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._title)
+        return self._title.value
+
+    @property
+    def url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._url)
+        return self._url.value
+
+    @property
+    def verified(self):
+        """
+        :type: bool
+        """
+        self._completeIfNotSet(self._verified)
+        return self._verified.value
+
+    def delete(self):
+        """
+        :calls: `DELETE /repos/:owner/:repo/keys/:id <http://developer.github.com/v3/repos/keys>`_
+        :rtype: None
+        """
+        headers, data = self._requester.requestJsonAndCheck(
+            "DELETE",
+            self.__customUrl
+        )
+
+    def edit(self, title=github.GithubObject.NotSet, key=github.GithubObject.NotSet):
+        """
+        :calls: `PATCH /repos/:owner/:repo/keys/:id <http://developer.github.com/v3/repos/keys>`_
+        :param title: string
+        :param key: string
+        :rtype: None
+        """
+        assert title is github.GithubObject.NotSet or isinstance(title, (str, unicode)), title
+        assert key is github.GithubObject.NotSet or isinstance(key, (str, unicode)), key
+        post_parameters = dict()
+        if title is not github.GithubObject.NotSet:
+            post_parameters["title"] = title
+        if key is not github.GithubObject.NotSet:
+            post_parameters["key"] = key
+        headers, data = self._requester.requestJsonAndCheck(
+            "PATCH",
+            self.__customUrl,
+            input=post_parameters
+        )
+        self._useAttributes(data)
+
+    def _initAttributes(self):
+        self._id = github.GithubObject.NotSet
+        self._key = github.GithubObject.NotSet
+        self._title = github.GithubObject.NotSet
+        self._url = github.GithubObject.NotSet
+        self._verified = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "id" in attributes:  # pragma no branch
+            self._id = self._makeIntAttribute(attributes["id"])
+        if "key" in attributes:  # pragma no branch
+            self._key = self._makeStringAttribute(attributes["key"])
+        if "title" in attributes:  # pragma no branch
+            self._title = self._makeStringAttribute(attributes["title"])
+        if "url" in attributes:  # pragma no branch
+            self._url = self._makeStringAttribute(attributes["url"])
+        if "verified" in attributes:  # pragma no branch
+            self._verified = self._makeBoolAttribute(attributes["verified"])

--- a/github/Requester.py
+++ b/github/Requester.py
@@ -1,0 +1,353 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Andrew Bettison <andrewb@zip.com.au>                          #
+# Copyright 2012 Dima Kukushkin <dima@kukushkin.me>                            #
+# Copyright 2012 Michael Woodworth <mwoodworth@upverter.com>                   #
+# Copyright 2012 Petteri Muilu <pmuilu@xena.(none)>                            #
+# Copyright 2012 Steve English <steve.english@navetas.com>                     #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Ed Jackson <ed.jackson@gmail.com>                             #
+# Copyright 2013 Jonathan J Hunt <hunt@braincorporation.com>                   #
+# Copyright 2013 Mark Roddy <markroddy@gmail.com>                              #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import logging
+import httplib
+import base64
+import urllib
+import urlparse
+import sys
+import Consts
+import re
+import os
+
+atLeastPython26 = sys.hexversion >= 0x02060000
+atLeastPython3 = sys.hexversion >= 0x03000000
+
+if atLeastPython26:
+    import json
+else:  # pragma no cover (Covered by all tests with Python 2.5)
+    import simplejson as json  # pragma no cover (Covered by all tests with Python 2.5)
+
+import GithubException
+
+
+class Requester:
+    __httpConnectionClass = httplib.HTTPConnection
+    __httpsConnectionClass = httplib.HTTPSConnection
+
+    @classmethod
+    def injectConnectionClasses(cls, httpConnectionClass, httpsConnectionClass):
+        cls.__httpConnectionClass = httpConnectionClass
+        cls.__httpsConnectionClass = httpsConnectionClass
+
+    @classmethod
+    def resetConnectionClasses(cls):
+        cls.__httpConnectionClass = httplib.HTTPConnection
+        cls.__httpsConnectionClass = httplib.HTTPSConnection
+
+    #############################################################
+    # For Debug
+    @classmethod
+    def setDebugFlag(cls, flag):
+        cls.DEBUG_FLAG = flag
+
+    @classmethod
+    def setOnCheckMe(cls, onCheckMe):
+        cls.ON_CHECK_ME = onCheckMe
+
+    DEBUG_FLAG = False
+
+    DEBUG_FRAME_BUFFER_SIZE = 1024
+
+    DEBUG_HEADER_KEY = "DEBUG_FRAME"
+
+    ON_CHECK_ME = None
+
+    def NEW_DEBUG_FRAME(self, requestHeader):
+        '''
+        Initialize a debug frame with requestHeader
+        Frame count is updated and will be attached to respond header
+        The structure of a frame: [requestHeader, statusCode, responseHeader, raw_data]
+        Some of them may be None
+        '''
+        if self.DEBUG_FLAG:  # pragma no branch (Flag always set in tests)
+            new_frame = [requestHeader, None, None, None]
+            if self._frameCount < self.DEBUG_FRAME_BUFFER_SIZE - 1:  # pragma no branch (Should be covered)
+                self._frameBuffer.append(new_frame)
+            else:
+                self._frameBuffer[0] = new_frame  # pragma no cover (Should be covered)
+
+            self._frameCount = len(self._frameBuffer) - 1
+
+    def DEBUG_ON_RESPONSE(self, statusCode, responseHeader, data):
+        '''
+        Update current frame with response
+        Current frame index will be attached to responseHeader
+        '''
+        if self.DEBUG_FLAG:  # pragma no branch (Flag always set in tests)
+            self._frameBuffer[self._frameCount][1:4] = [statusCode, responseHeader, data]
+            responseHeader[self.DEBUG_HEADER_KEY] = self._frameCount
+
+    def check_me(self, obj):
+        if self.DEBUG_FLAG and self.ON_CHECK_ME is not None:  # pragma no branch (Flag always set in tests)
+            frame = None
+            if self.DEBUG_HEADER_KEY in obj._headers:
+                frame_index = obj._headers[self.DEBUG_HEADER_KEY]
+                frame = self._frameBuffer[frame_index]
+            self.ON_CHECK_ME(obj, frame)
+
+    def _initializeDebugFeature(self):
+        self._frameCount = 0
+        self._frameBuffer = []
+
+    #############################################################
+
+    def __init__(self, login_or_token, password, base_url, timeout, client_id, client_secret, user_agent, per_page, api_preview):
+        self._initializeDebugFeature()
+
+        if password is not None:
+            login = login_or_token
+            if atLeastPython3:
+                self.__authorizationHeader = "Basic " + base64.b64encode((login + ":" + password).encode("utf-8")).decode("utf-8").replace('\n', '')  # pragma no cover (Covered by Authentication.testAuthorizationHeaderWithXxx with Python 3)
+            else:
+                self.__authorizationHeader = "Basic " + base64.b64encode(login + ":" + password).replace('\n', '')
+        elif login_or_token is not None:
+            token = login_or_token
+            self.__authorizationHeader = "token " + token
+        else:
+            self.__authorizationHeader = None
+
+        self.__base_url = base_url
+        o = urlparse.urlparse(base_url)
+        self.__hostname = o.hostname
+        self.__port = o.port
+        self.__prefix = o.path
+        self.__timeout = timeout
+        self.__scheme = o.scheme
+        if o.scheme == "https":
+            self.__connectionClass = self.__httpsConnectionClass
+        elif o.scheme == "http":
+            self.__connectionClass = self.__httpConnectionClass
+        else:
+            assert False, "Unknown URL scheme"
+        self.rate_limiting = (-1, -1)
+        self.rate_limiting_resettime = 0
+        self.FIX_REPO_GET_GIT_REF = True
+        self.per_page = per_page
+
+        self.oauth_scopes = None
+
+        self.__clientId = client_id
+        self.__clientSecret = client_secret
+
+        assert user_agent is not None, 'github now requires a user-agent. ' \
+            'See http://developer.github.com/v3/#user-agent-required'
+        self.__userAgent = user_agent
+        self.__apiPreview = api_preview
+
+    def requestJsonAndCheck(self, verb, url, parameters=None, headers=None, input=None, cnx=None):
+        return self.__check(*self.requestJson(verb, url, parameters, headers, input, cnx))
+
+    def requestMultipartAndCheck(self, verb, url, parameters=None, headers=None, input=None):
+        return self.__check(*self.requestMultipart(verb, url, parameters, headers, input))
+
+    def __check(self, status, responseHeaders, output):
+        output = self.__structuredFromJson(output)
+        if status >= 400:
+            raise self.__createException(status, responseHeaders, output)
+        return responseHeaders, output
+
+    def __createException(self, status, headers, output):
+        if status == 401 and output.get("message") == "Bad credentials":
+            cls = GithubException.BadCredentialsException
+        elif status == 401 and 'x-github-otp' in headers and re.match(r'.*required.*', headers['x-github-otp']):
+            cls = GithubException.TwoFactorException  # pragma no cover (Should be covered)
+        elif status == 403 and output.get("message").startswith("Missing or invalid User Agent string"):
+            cls = GithubException.BadUserAgentException
+        elif status == 403 and output.get("message").startswith("API Rate Limit Exceeded"):
+            cls = GithubException.RateLimitExceededException
+        elif status == 404 and output.get("message") == "Not Found":
+            cls = GithubException.UnknownObjectException
+        else:
+            cls = GithubException.GithubException
+        return cls(status, output)
+
+    def __structuredFromJson(self, data):
+        if len(data) == 0:
+            return None
+        else:
+            if atLeastPython3 and isinstance(data, bytes):  # pragma no branch (Covered by Issue142.testDecodeJson with Python 3)
+                data = data.decode("utf-8")  # pragma no cover (Covered by Issue142.testDecodeJson with Python 3)
+            try:
+                return json.loads(data)
+            except ValueError, e:
+                return {'data': data}
+
+    def requestJson(self, verb, url, parameters=None, headers=None, input=None, cnx=None):
+        def encode(input):
+            return "application/json", json.dumps(input)
+
+        return self.__requestEncode(cnx, verb, url, parameters, headers, input, encode)
+
+    def requestMultipart(self, verb, url, parameters=None, headers=None, input=None):
+        def encode(input):
+            boundary = "----------------------------3c3ba8b523b2"
+            eol = "\r\n"
+
+            encoded_input = ""
+            for name, value in input.iteritems():
+                encoded_input += "--" + boundary + eol
+                encoded_input += "Content-Disposition: form-data; name=\"" + name + "\"" + eol
+                encoded_input += eol
+                encoded_input += value + eol
+            encoded_input += "--" + boundary + "--" + eol
+            return "multipart/form-data; boundary=" + boundary, encoded_input
+
+        return self.__requestEncode(None, verb, url, parameters, headers, input, encode)
+
+    def __requestEncode(self, cnx, verb, url, parameters, requestHeaders, input, encode):
+        assert verb in ["HEAD", "GET", "POST", "PATCH", "PUT", "DELETE"]
+        if parameters is None:
+            parameters = dict()
+        if requestHeaders is None:
+            requestHeaders = dict()
+
+        self.__authenticate(url, requestHeaders, parameters)
+        requestHeaders["User-Agent"] = self.__userAgent
+        if self.__apiPreview:
+            requestHeaders["Accept"] = "application/vnd.github.moondragon+json"
+
+        url = self.__makeAbsoluteUrl(url)
+        url = self.__addParametersToUrl(url, parameters)
+
+        encoded_input = "null"
+        if input is not None:
+            requestHeaders["Content-Type"], encoded_input = encode(input)
+
+        self.NEW_DEBUG_FRAME(requestHeaders)
+
+        status, responseHeaders, output = self.__requestRaw(cnx, verb, url, requestHeaders, encoded_input)
+
+        if "x-ratelimit-remaining" in responseHeaders and "x-ratelimit-limit" in responseHeaders:
+            self.rate_limiting = (int(responseHeaders["x-ratelimit-remaining"]), int(responseHeaders["x-ratelimit-limit"]))
+        if "x-ratelimit-reset" in responseHeaders:
+            self.rate_limiting_resettime = int(responseHeaders["x-ratelimit-reset"])
+
+        if "x-oauth-scopes" in responseHeaders:
+            self.oauth_scopes = responseHeaders["x-oauth-scopes"].split(", ")
+
+        self.DEBUG_ON_RESPONSE(status, responseHeaders, output)
+
+        return status, responseHeaders, output
+
+    def __requestRaw(self, cnx, verb, url, requestHeaders, input):
+        if cnx is None:
+            cnx = self.__createConnection()
+        else:
+            assert cnx == "status"
+            cnx = self.__httpsConnectionClass("status.github.com", 443)
+        cnx.request(
+            verb,
+            url,
+            input,
+            requestHeaders
+        )
+        response = cnx.getresponse()
+
+        status = response.status
+        responseHeaders = dict((k.lower(), v) for k, v in response.getheaders())
+        output = response.read()
+
+        cnx.close()
+
+        self.__log(verb, url, requestHeaders, input, status, responseHeaders, output)
+
+        return status, responseHeaders, output
+
+    def __authenticate(self, url, requestHeaders, parameters):
+        if self.__clientId and self.__clientSecret and "client_id=" not in url:
+            parameters["client_id"] = self.__clientId
+            parameters["client_secret"] = self.__clientSecret
+        if self.__authorizationHeader is not None:
+            requestHeaders["Authorization"] = self.__authorizationHeader
+
+    def __makeAbsoluteUrl(self, url):
+        # URLs generated locally will be relative to __base_url
+        # URLs returned from the server will start with __base_url
+        if url.startswith("/"):
+            url = self.__prefix + url
+        else:
+            o = urlparse.urlparse(url)
+            assert o.hostname == self.__hostname
+            assert o.path.startswith(self.__prefix)
+            assert o.port == self.__port
+            url = o.path
+            if o.query != "":
+                url += "?" + o.query
+        return url
+
+    def __addParametersToUrl(self, url, parameters):
+        if len(parameters) == 0:
+            return url
+        else:
+            return url + "?" + urllib.urlencode(parameters)
+
+    def __createConnection(self):
+        kwds = {}
+        if not atLeastPython3:  # pragma no branch (Branch useful only with Python 3)
+            kwds["strict"] = True  # Useless in Python3, would generate a deprecation warning
+        if atLeastPython26:  # pragma no branch (Branch useful only with Python 2.5)
+            kwds["timeout"] = self.__timeout  # Did not exist before Python2.6
+
+        ##
+        ## Connect through a proxy server with authentication, if http_proxy
+        ## set.
+        ## http_proxy: http://user:password@proxy_host:proxy_port
+        ##
+        proxy_uri = os.getenv('http_proxy') or os.getenv('HTTP_PROXY')
+        if proxy_uri is not None:
+            url = urlparse.urlparse(proxy_uri)
+            conn = self.__connectionClass(url.hostname, url.port, **kwds)
+            headers = {}
+            if url.username and url.password:
+                auth = '%s:%s' % (url.username, url.password)
+                headers['Proxy-Authorization'] = 'Basic ' + base64.b64encode(auth)
+            conn.set_tunnel(self.__hostname, self.__port, headers)
+        else:
+            conn = self.__connectionClass(self.__hostname, self.__port, **kwds)
+
+        return conn
+
+    def __log(self, verb, url, requestHeaders, input, status, responseHeaders, output):
+        logger = logging.getLogger(__name__)
+        if logger.isEnabledFor(logging.DEBUG):
+            if "Authorization" in requestHeaders:
+                if requestHeaders["Authorization"].startswith("Basic"):
+                    requestHeaders["Authorization"] = "Basic (login and password removed)"
+                elif requestHeaders["Authorization"].startswith("token"):
+                    requestHeaders["Authorization"] = "token (oauth token removed)"
+                else:  # pragma no cover (Cannot happen, but could if we add an authentication method => be prepared)
+                    requestHeaders["Authorization"] = "(unknown auth removed)"  # pragma no cover (Cannot happen, but could if we add an authentication method => be prepared)
+            logger.debug("%s %s://%s%s %s %s ==> %i %s %s", str(verb), self.__scheme, self.__hostname, str(url), str(requestHeaders), str(input), status, str(responseHeaders), str(output))

--- a/github/Stargazer.py
+++ b/github/Stargazer.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Christopher Gilbert <christopher.john.gilbert@gmail.com>      #
+# Copyright 2012 Steve English <steve.english@navetas.com>                     #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Adrian Petrescu <adrian.petrescu@maluuba.com>                 #
+# Copyright 2013 Mark Roddy <markroddy@gmail.com>                              #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2013 martinqt <m.ki2@laposte.net>                                  #
+# Copyright 2015 Dan Vanderkam <danvdk@gmail.com>                              #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github
+
+
+class Stargazer(github.GithubObject.NonCompletableGithubObject):
+    """
+    This class represents Stargazers with the date of starring as returned by
+    https://developer.github.com/v3/activity/starring/#alternative-response-with-star-creation-timestamps
+    """
+    @property
+    def starred_at(self):
+        """
+        :type: datetime.datetime
+        """
+        return self._starred_at.value
+
+    @property
+    def user(self):
+        """
+        :type: :class:`github.NamedUser`
+        """
+        return self._user.value
+
+    def _initAttributes(self):
+        self._starred_at = github.GithubObject.NotSet
+        self._user = github.GithubObject.NotSet
+        self._url = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if 'starred_at' in attributes:
+            self._starred_at = self._makeDatetimeAttribute(attributes['starred_at'])
+        if 'user' in attributes:
+            self._user = self._makeClassAttribute(github.NamedUser.NamedUser, attributes['user'])

--- a/github/StatsCodeFrequency.py
+++ b/github/StatsCodeFrequency.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+
+
+class StatsCodeFrequency(github.GithubObject.NonCompletableGithubObject):
+    """
+    This class represents statistics of code frequency. The reference can be found here http://developer.github.com/v3/repos/statistics/#get-the-number-of-additions-and-deletions-per-week
+    """
+
+    @property
+    def week(self):
+        """
+        :type: datetime.datetime
+        """
+        return self._week.value
+
+    @property
+    def additions(self):
+        """
+        :type: int
+        """
+        return self._additions.value
+
+    @property
+    def deletions(self):
+        """
+        :type: int
+        """
+        return self._deletions.value
+
+    def _initAttributes(self):
+        self._week = github.GithubObject.NotSet
+        self._additions = github.GithubObject.NotSet
+        self._deletions = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        self._week = self._makeTimestampAttribute(attributes[0])
+        self._additions = self._makeIntAttribute(attributes[1])
+        self._deletions = self._makeIntAttribute(attributes[2])

--- a/github/StatsCommitActivity.py
+++ b/github/StatsCommitActivity.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+
+
+class StatsCommitActivity(github.GithubObject.NonCompletableGithubObject):
+    """
+    This class represents statistics of commit activity. The reference can be found here http://developer.github.com/v3/repos/statistics/#get-the-last-year-of-commit-activity-data
+    """
+
+    @property
+    def week(self):
+        """
+        :type: datetime.datetime
+        """
+        return self._week.value
+
+    @property
+    def total(self):
+        """
+        :type: int
+        """
+        return self._total.value
+
+    @property
+    def days(self):
+        """
+        :type: list of int
+        """
+        return self._days.value
+
+    def _initAttributes(self):
+        self._week = github.GithubObject.NotSet
+        self._total = github.GithubObject.NotSet
+        self._days = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "week" in attributes:  # pragma no branch
+            self._week = self._makeTimestampAttribute(attributes["week"])
+        if "total" in attributes:  # pragma no branch
+            self._total = self._makeIntAttribute(attributes["total"])
+        if "days" in attributes:  # pragma no branch
+            self._days = self._makeListOfIntsAttribute(attributes["days"])

--- a/github/StatsContributor.py
+++ b/github/StatsContributor.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+
+import github.NamedUser
+
+
+class StatsContributor(github.GithubObject.NonCompletableGithubObject):
+    """
+    This class represents statistics of a contibutor. The reference can be found here http://developer.github.com/v3/repos/statistics/#get-contributors-list-with-additions-deletions-and-commit-counts
+    """
+
+    class Week(github.GithubObject.NonCompletableGithubObject):
+        """
+        This class represents weekly statistics of a contibutor.
+        """
+
+        @property
+        def w(self):
+            """
+            :type: datetime.datetime
+            """
+            return self._w.value
+
+        @property
+        def a(self):
+            """
+            :type: int
+            """
+            return self._a.value
+
+        @property
+        def d(self):
+            """
+            :type: int
+            """
+            return self._d.value
+
+        @property
+        def c(self):
+            """
+            :type: int
+            """
+            return self._c.value
+
+        def _initAttributes(self):
+            self._w = github.GithubObject.NotSet
+            self._a = github.GithubObject.NotSet
+            self._d = github.GithubObject.NotSet
+            self._c = github.GithubObject.NotSet
+
+        def _useAttributes(self, attributes):
+            if "w" in attributes:  # pragma no branch
+                self._w = self._makeTimestampAttribute(attributes["w"])
+            if "a" in attributes:  # pragma no branch
+                self._a = self._makeIntAttribute(attributes["a"])
+            if "d" in attributes:  # pragma no branch
+                self._d = self._makeIntAttribute(attributes["d"])
+            if "c" in attributes:  # pragma no branch
+                self._c = self._makeIntAttribute(attributes["c"])
+
+    @property
+    def author(self):
+        """
+        :type: :class:`github.NamedUser.NamedUser`
+        """
+        return self._author.value
+
+    @property
+    def total(self):
+        """
+        :type: int
+        """
+        return self._total.value
+
+    @property
+    def weeks(self):
+        """
+        :type: list of :class:`.Week`
+        """
+        return self._weeks.value
+
+    def _initAttributes(self):
+        self._author = github.GithubObject.NotSet
+        self._total = github.GithubObject.NotSet
+        self._weeks = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "author" in attributes:  # pragma no branch
+            self._author = self._makeClassAttribute(github.NamedUser.NamedUser, attributes["author"])
+        if "total" in attributes:  # pragma no branch
+            self._total = self._makeIntAttribute(attributes["total"])
+        if "weeks" in attributes:  # pragma no branch
+            self._weeks = self._makeListOfClassesAttribute(self.Week, attributes["weeks"])

--- a/github/StatsParticipation.py
+++ b/github/StatsParticipation.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+
+import github.NamedUser
+
+
+class StatsParticipation(github.GithubObject.NonCompletableGithubObject):
+    """
+    This class represents statistics of participation. The reference can be found here http://developer.github.com/v3/repos/statistics/#get-the-weekly-commit-count-for-the-repo-owner-and-everyone-else
+    """
+
+    @property
+    def all(self):
+        """
+        :type: list of int
+        """
+        return self._all.value
+
+    @property
+    def owner(self):
+        """
+        :type: list of int
+        """
+        return self._owner.value
+
+    def _initAttributes(self):
+        self._all = github.GithubObject.NotSet
+        self._owner = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "all" in attributes:  # pragma no branch
+            self._all = self._makeListOfIntsAttribute(attributes["all"])
+        if "owner" in attributes:  # pragma no branch
+            self._owner = self._makeListOfIntsAttribute(attributes["owner"])

--- a/github/StatsPunchCard.py
+++ b/github/StatsPunchCard.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+
+import github.NamedUser
+
+
+class StatsPunchCard(github.GithubObject.NonCompletableGithubObject):
+    """
+    This class represents the punch card. The reference can be found here http://developer.github.com/v3/repos/statistics/#get-the-number-of-commits-per-hour-in-each-day
+    """
+
+    def get(self, day, hour):
+        """
+        Get a specific element
+        :param day: int
+        :param hour: int
+        :rtype: int
+        """
+        return self._dict[(day, hour)]
+
+    def _initAttributes(self):
+        self._dict = {}
+
+    def _useAttributes(self, attributes):
+        for day, hour, commits in attributes:
+            self._dict[(day, hour)] = commits

--- a/github/Status.py
+++ b/github/Status.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+
+
+class Status(github.GithubObject.NonCompletableGithubObject):
+    """
+    This class represents status as defined in https://status.github.com/api
+    """
+
+    @property
+    def status(self):
+        """
+        :type: string
+        """
+        return self._status.value
+
+    @property
+    def last_updated(self):
+        """
+        :type: datetime.datetime
+        """
+        return self._last_updated.value
+
+    def _initAttributes(self):
+        self._status = github.GithubObject.NotSet
+        self._last_updated = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "status" in attributes:  # pragma no branch
+            self._status = self._makeStringAttribute(attributes["status"])
+        if "last_updated" in attributes:  # pragma no branch
+            self._last_updated = self._makeDatetimeAttribute(attributes["last_updated"])

--- a/github/StatusMessage.py
+++ b/github/StatusMessage.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+
+
+class StatusMessage(github.GithubObject.NonCompletableGithubObject):
+    """
+    This class represents status messages as defined in https://status.github.com/api
+    """
+
+    @property
+    def body(self):
+        """
+        :type: string
+        """
+        return self._body.value
+
+    @property
+    def status(self):
+        """
+        :type: string
+        """
+        return self._status.value
+
+    @property
+    def created_on(self):
+        """
+        :type: datetime.datetime
+        """
+        return self._created_on.value
+
+    def _initAttributes(self):
+        self._status = github.GithubObject.NotSet
+        self._created_on = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "body" in attributes:  # pragma no branch
+            self._body = self._makeStringAttribute(attributes["body"])
+        if "status" in attributes:  # pragma no branch
+            self._status = self._makeStringAttribute(attributes["status"])
+        if "created_on" in attributes:  # pragma no branch
+            self._created_on = self._makeDatetimeAttribute(attributes["created_on"])

--- a/github/Tag.py
+++ b/github/Tag.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2013 martinqt <m.ki2@laposte.net>                                  #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+
+import github.Commit
+
+
+class Tag(github.GithubObject.NonCompletableGithubObject):
+    """
+    This class represents Tags. The reference can be found here http://developer.github.com/v3/git/tags/
+    """
+
+    @property
+    def commit(self):
+        """
+        :type: :class:`github.Commit.Commit`
+        """
+        return self._commit.value
+
+    @property
+    def name(self):
+        """
+        :type: string
+        """
+        return self._name.value
+
+    @property
+    def tarball_url(self):
+        """
+        :type: string
+        """
+        return self._tarball_url.value
+
+    @property
+    def zipball_url(self):
+        """
+        :type: string
+        """
+        return self._zipball_url.value
+
+    def _initAttributes(self):
+        self._commit = github.GithubObject.NotSet
+        self._name = github.GithubObject.NotSet
+        self._tarball_url = github.GithubObject.NotSet
+        self._zipball_url = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "commit" in attributes:  # pragma no branch
+            self._commit = self._makeClassAttribute(github.Commit.Commit, attributes["commit"])
+        if "name" in attributes:  # pragma no branch
+            self._name = self._makeStringAttribute(attributes["name"])
+        if "tarball_url" in attributes:  # pragma no branch
+            self._tarball_url = self._makeStringAttribute(attributes["tarball_url"])
+        if "zipball_url" in attributes:  # pragma no branch
+            self._zipball_url = self._makeStringAttribute(attributes["zipball_url"])

--- a/github/Team.py
+++ b/github/Team.py
@@ -1,0 +1,286 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2013 martinqt <m.ki2@laposte.net>                                  #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+import github.PaginatedList
+
+import github.Repository
+import github.NamedUser
+
+
+class Team(github.GithubObject.CompletableGithubObject):
+    """
+    This class represents Teams. The reference can be found here http://developer.github.com/v3/orgs/teams/
+    """
+
+    @property
+    def id(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._id)
+        return self._id.value
+
+    @property
+    def members_count(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._members_count)
+        return self._members_count.value
+
+    @property
+    def members_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._members_url)
+        return self._members_url.value
+
+    @property
+    def name(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._name)
+        return self._name.value
+
+    @property
+    def permission(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._permission)
+        return self._permission.value
+
+    @property
+    def repos_count(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._repos_count)
+        return self._repos_count.value
+
+    @property
+    def repositories_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._repositories_url)
+        return self._repositories_url.value
+
+    @property
+    def slug(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._slug)
+        return self._slug.value
+
+    @property
+    def url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._url)
+        return self._url.value
+
+    def add_to_members(self, member):
+        """
+        :calls: `PUT /teams/:id/members/:user <http://developer.github.com/v3/orgs/teams>`_
+        :param member: :class:`github.NamedUser.NamedUser`
+        :rtype: None
+        """
+        assert isinstance(member, github.NamedUser.NamedUser), member
+        headers, data = self._requester.requestJsonAndCheck(
+            "PUT",
+            self.url + "/members/" + member._identity
+        )
+
+    def add_membership(self, member):
+        """
+        :calls: `PUT /teams/:id/memberships/:user <http://developer.github.com/v3/orgs/teams>`_
+        :param member: :class:`github.Nameduser.NamedUser`
+        :rtype: None
+        """
+        assert isinstance(member, github.NamedUser.NamedUser), member
+        headers, data = self._requester.requestjsonandcheck(
+            "PUT",
+            self.url + "/memberships/" + member._identity
+        )
+
+    def add_to_repos(self, repo):
+        """
+        :calls: `PUT /teams/:id/repos/:org/:repo <http://developer.github.com/v3/orgs/teams>`_
+        :param repo: :class:`github.Repository.Repository`
+        :rtype: None
+        """
+        assert isinstance(repo, github.Repository.Repository), repo
+        headers, data = self._requester.requestJsonAndCheck(
+            "PUT",
+            self.url + "/repos/" + repo._identity
+        )
+
+    def delete(self):
+        """
+        :calls: `DELETE /teams/:id <http://developer.github.com/v3/orgs/teams>`_
+        :rtype: None
+        """
+        headers, data = self._requester.requestJsonAndCheck(
+            "DELETE",
+            self.url
+        )
+
+    def edit(self, name, permission=github.GithubObject.NotSet):
+        """
+        :calls: `PATCH /teams/:id <http://developer.github.com/v3/orgs/teams>`_
+        :param name: string
+        :param permission: string
+        :rtype: None
+        """
+        assert isinstance(name, (str, unicode)), name
+        assert permission is github.GithubObject.NotSet or isinstance(permission, (str, unicode)), permission
+        post_parameters = {
+            "name": name,
+        }
+        if permission is not github.GithubObject.NotSet:
+            post_parameters["permission"] = permission
+        headers, data = self._requester.requestJsonAndCheck(
+            "PATCH",
+            self.url,
+            input=post_parameters
+        )
+        self._useAttributes(data)
+
+    def get_members(self):
+        """
+        :calls: `GET /teams/:id/members <http://developer.github.com/v3/orgs/teams>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.NamedUser.NamedUser`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.NamedUser.NamedUser,
+            self._requester,
+            self.url + "/members",
+            None
+        )
+
+    def get_repos(self):
+        """
+        :calls: `GET /teams/:id/repos <http://developer.github.com/v3/orgs/teams>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Repository.Repository`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.Repository.Repository,
+            self._requester,
+            self.url + "/repos",
+            None
+        )
+
+    def has_in_members(self, member):
+        """
+        :calls: `GET /teams/:id/members/:user <http://developer.github.com/v3/orgs/teams>`_
+        :param member: :class:`github.NamedUser.NamedUser`
+        :rtype: bool
+        """
+        assert isinstance(member, github.NamedUser.NamedUser), member
+        status, headers, data = self._requester.requestJson(
+            "GET",
+            self.url + "/members/" + member._identity
+        )
+        return status == 204
+
+    def has_in_repos(self, repo):
+        """
+        :calls: `GET /teams/:id/repos/:owner/:repo <http://developer.github.com/v3/orgs/teams>`_
+        :param repo: :class:`github.Repository.Repository`
+        :rtype: bool
+        """
+        assert isinstance(repo, github.Repository.Repository), repo
+        status, headers, data = self._requester.requestJson(
+            "GET",
+            self.url + "/repos/" + repo._identity
+        )
+        return status == 204
+
+    def remove_from_members(self, member):
+        """
+        :calls: `DELETE /teams/:id/members/:user <http://developer.github.com/v3/orgs/teams>`_
+        :param member: :class:`github.NamedUser.NamedUser`
+        :rtype: None
+        """
+        assert isinstance(member, github.NamedUser.NamedUser), member
+        headers, data = self._requester.requestJsonAndCheck(
+            "DELETE",
+            self.url + "/members/" + member._identity
+        )
+
+    def remove_from_repos(self, repo):
+        """
+        :calls: `DELETE /teams/:id/repos/:owner/:repo <http://developer.github.com/v3/orgs/teams>`_
+        :param repo: :class:`github.Repository.Repository`
+        :rtype: None
+        """
+        assert isinstance(repo, github.Repository.Repository), repo
+        headers, data = self._requester.requestJsonAndCheck(
+            "DELETE",
+            self.url + "/repos/" + repo._identity
+        )
+
+    @property
+    def _identity(self):
+        return self.id
+
+    def _initAttributes(self):
+        self._id = github.GithubObject.NotSet
+        self._members_count = github.GithubObject.NotSet
+        self._members_url = github.GithubObject.NotSet
+        self._name = github.GithubObject.NotSet
+        self._permission = github.GithubObject.NotSet
+        self._repos_count = github.GithubObject.NotSet
+        self._repositories_url = github.GithubObject.NotSet
+        self._slug = github.GithubObject.NotSet
+        self._url = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "id" in attributes:  # pragma no branch
+            self._id = self._makeIntAttribute(attributes["id"])
+        if "members_count" in attributes:  # pragma no branch
+            self._members_count = self._makeIntAttribute(attributes["members_count"])
+        if "members_url" in attributes:  # pragma no branch
+            self._members_url = self._makeStringAttribute(attributes["members_url"])
+        if "name" in attributes:  # pragma no branch
+            self._name = self._makeStringAttribute(attributes["name"])
+        if "permission" in attributes:  # pragma no branch
+            self._permission = self._makeStringAttribute(attributes["permission"])
+        if "repos_count" in attributes:  # pragma no branch
+            self._repos_count = self._makeIntAttribute(attributes["repos_count"])
+        if "repositories_url" in attributes:  # pragma no branch
+            self._repositories_url = self._makeStringAttribute(attributes["repositories_url"])
+        if "slug" in attributes:  # pragma no branch
+            self._slug = self._makeStringAttribute(attributes["slug"])
+        if "url" in attributes:  # pragma no branch
+            self._url = self._makeStringAttribute(attributes["url"])

--- a/github/UserKey.py
+++ b/github/UserKey.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2013 martinqt <m.ki2@laposte.net>                                  #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+
+
+class UserKey(github.GithubObject.CompletableGithubObject):
+    """
+    This class represents UserKeys. The reference can be found here http://developer.github.com/v3/users/keys/
+    """
+
+    @property
+    def id(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._id)
+        return self._id.value
+
+    @property
+    def key(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._key)
+        return self._key.value
+
+    @property
+    def title(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._title)
+        return self._title.value
+
+    @property
+    def url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._url)
+        return self._url.value
+
+    @property
+    def verified(self):
+        """
+        :type: bool
+        """
+        self._completeIfNotSet(self._verified)
+        return self._verified.value
+
+    def delete(self):
+        """
+        :calls: `DELETE /user/keys/:id <http://developer.github.com/v3/users/keys>`_
+        :rtype: None
+        """
+        headers, data = self._requester.requestJsonAndCheck(
+            "DELETE",
+            self.url
+        )
+
+    def edit(self, title=github.GithubObject.NotSet, key=github.GithubObject.NotSet):
+        """
+        :calls: `PATCH /user/keys/:id <http://developer.github.com/v3/users/keys>`_
+        :param title: string
+        :param key: string
+        :rtype: None
+        """
+        assert title is github.GithubObject.NotSet or isinstance(title, (str, unicode)), title
+        assert key is github.GithubObject.NotSet or isinstance(key, (str, unicode)), key
+        post_parameters = dict()
+        if title is not github.GithubObject.NotSet:
+            post_parameters["title"] = title
+        if key is not github.GithubObject.NotSet:
+            post_parameters["key"] = key
+        headers, data = self._requester.requestJsonAndCheck(
+            "PATCH",
+            self.url,
+            input=post_parameters
+        )
+        self._useAttributes(data)
+
+    def _initAttributes(self):
+        self._id = github.GithubObject.NotSet
+        self._key = github.GithubObject.NotSet
+        self._title = github.GithubObject.NotSet
+        self._url = github.GithubObject.NotSet
+        self._verified = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "id" in attributes:  # pragma no branch
+            self._id = self._makeIntAttribute(attributes["id"])
+        if "key" in attributes:  # pragma no branch
+            self._key = self._makeStringAttribute(attributes["key"])
+        if "title" in attributes:  # pragma no branch
+            self._title = self._makeStringAttribute(attributes["title"])
+        if "url" in attributes:  # pragma no branch
+            self._url = self._makeStringAttribute(attributes["url"])
+        if "verified" in attributes:  # pragma no branch
+            self._verified = self._makeBoolAttribute(attributes["verified"])

--- a/github/__init__.py
+++ b/github/__init__.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+"""
+The primary class you will instanciate is :class:`github.MainClass.Github`.
+From its ``get_``, ``create_`` methods, you will obtain instances of all Github objects
+like :class:`github.NamedUser.NamedUser` or :class:`github.Repository.Repository`.
+
+All classes inherit from :class:`github.GithubObject.GithubObject`.
+"""
+
+import logging
+
+from MainClass import Github
+from GithubException import GithubException, BadCredentialsException, UnknownObjectException, BadUserAgentException, RateLimitExceededException, BadAttributeException
+from InputFileContent import InputFileContent
+from InputGitAuthor import InputGitAuthor
+from InputGitTreeElement import InputGitTreeElement
+
+
+def enable_console_debug_logging():  # pragma no cover (Function useful only outside test environment)
+    """
+    This function sets up a very simple logging configuration (log everything on standard output) that is useful for troubleshooting.
+    """
+
+    logger = logging.getLogger("github")
+    logger.setLevel(logging.DEBUG)
+    logger.addHandler(logging.StreamHandler())

--- a/github_utils.py
+++ b/github_utils.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import logging
 
@@ -19,12 +20,27 @@ REPO = 't2-cli'
 CRASH_REPORTER_HOST = 'http://crash-reporter.tessel.io'
 
 
+def issue_url(issue_number):
+    """
+    Returns the GitHub issue URL.
+    """
+    if is_appengine_local():
+        repo_name = '%s/%s' % (DEBUG_OWNER, DEBUG_REPO)
+    else:
+        repo_name = '%s/%s' % (OWNER, REPO)
+
+    return 'https://github.com/%s/issues/%s' % (repo_name, issue_number)
+
+
 class GithubOrchestrator(object):
     """
     Orchestrates all communication with GitHub via a task queue.
     """
     __QUEUE__ = 'github-queue'
+    # Every x times that we need to update the task with a comment
     __NOTIFY_FREQUENCY__ = 1
+    # seconds
+    __SCHEDULE_DELAY__ = 10
 
     @classmethod
     def manage_github_issue(cls, crash_report):
@@ -32,13 +48,27 @@ class GithubOrchestrator(object):
         Manages the GitHub issue.
         """
         if crash_report is not None:
+            issue = crash_report.issue
             count = CrashReport.get_count(crash_report.name)
-            if count == 1:
-                # new crash
-                deferred.defer(
-                    GithubOrchestrator.create_issue_job, crash_report.fingerprint, _queue=GithubOrchestrator.__QUEUE__)
-                logging.info(
-                    'Enqueued job for new issue on GitHub for fingerprint %s' % crash_report.fingerprint)
+            if issue is None:
+                if count > 1:
+                    # there is a chance that we get a new crash before an issue was submitted before.
+                    # in this case we postpone the management of this crash.
+                    delta = datetime.timedelta(seconds=GithubOrchestrator.__SCHEDULE_DELAY__)
+                    countdown = datetime.datetime.now() + delta
+                    deferred.defer(
+                        GithubOrchestrator.manage_github_issue_as_task,
+                        crash_report.fingerprint,
+                        countdown=countdown,
+                        _queue=GithubOrchestrator.__QUEUE__)
+                    logging.info('Enqueued management task for the future for %s' % crash_report.fingerprint)
+                else:
+                    # new crash
+                    deferred.defer(
+                        GithubOrchestrator.create_issue_job,
+                        crash_report.fingerprint, _queue=GithubOrchestrator.__QUEUE__)
+                    logging.info(
+                        'Enqueued job for new issue on GitHub for fingerprint %s' % crash_report.fingerprint)
             elif count > 0 and count % GithubOrchestrator.__NOTIFY_FREQUENCY__ == 0:
                 # add comments for an existing crash
                 deferred.defer(
@@ -47,6 +77,14 @@ class GithubOrchestrator(object):
                     'Enqueued job for adding comments on GitHub for fingerprint %s' % crash_report.fingerprint)
             else:
                 logging.debug('No pending tasks.')
+
+    @classmethod
+    def manage_github_issue_as_task(cls, fingerprint):
+        """
+        Github Management API as a task.
+        """
+        crash_report = CrashReport.get_crash(fingerprint)
+        GithubOrchestrator.manage_github_issue(crash_report)
 
     @classmethod
     def create_issue_job(cls, fingerprint):
@@ -71,6 +109,9 @@ class GithubOrchestrator(object):
 
     @classmethod
     def add_comment_job(cls, fingerprint):
+        """
+        Handles the create comment job
+        """
         try:
             github_client = GithubClient()
             crash_report = CrashReport.get_crash(fingerprint)
@@ -110,10 +151,10 @@ class GithubClient(object):
                 self.repo_name = '%s/%s' % (OWNER, REPO)
             self.github_client = Github(login_or_token=github_token)
 
-    """
-    Submits a GitHub issue for a given fingerprint.
-    """
     def create_issue(self, crash_report):
+        """
+        Submits a GitHub issue for a given fingerprint.
+        """
         fingerprint = crash_report.fingerprint
         # get repository
         repository = self.github_client.get_repo(self.repo_name)
@@ -126,10 +167,10 @@ class GithubClient(object):
 
         return issue
 
-    """
-    Updates a crash report with the comment.
-    """
     def create_comment(self, crash_report):
+        """
+        Updates a crash report with the comment.
+        """
         count = CrashReport.get_count(crash_report.name)
         issue_number = int(float(crash_report.issue))
         comment_body = self.issue_comment(count)

--- a/github_utils.py
+++ b/github_utils.py
@@ -1,23 +1,145 @@
 import json
-from github import Github
+import logging
 
+from google.appengine.ext import deferred
+
+from github import Github
+from model import CrashReport
+from util import is_appengine_local, crash_uri, CrashReports
+
+# constants
 TOKEN_KEY = 'github_token'
+
+DEBUG_OWNER = 'tikurahul'
+DEBUG_REPO = 'sandbox'
+DEBUG_CRASH_REPORTER_HOST = 'http://localhost:8080'
+
 OWNER = 'tessel'
 REPO = 't2-cli'
+CRASH_REPORTER_HOST = 'http://crash-reporter.tessel.io'
+
+
+class GithubOrchestrator(object):
+    """
+    Orchestrates all communication with GitHub via a task queue.
+    """
+    __QUEUE__ = 'github-queue'
+    __NOTIFY_FREQUENCY__ = 1
+
+    @classmethod
+    def manage_github_issue(cls, crash_report):
+        """
+        Manages the GitHub issue.
+        """
+        if crash_report is not None:
+            count = CrashReport.get_count(crash_report.name)
+            if count == 1:
+                # new crash
+                deferred.defer(
+                    GithubOrchestrator.create_issue_job, crash_report.fingerprint, _queue=GithubOrchestrator.__QUEUE__)
+                logging.info(
+                    'Enqueued job for new issue on GitHub for fingerprint %s' % crash_report.fingerprint)
+            elif count > 0 and count % GithubOrchestrator.__NOTIFY_FREQUENCY__ == 0:
+                # add comments for an existing crash
+                deferred.defer(
+                    GithubOrchestrator.add_comment_job, crash_report.fingerprint, _queue=GithubOrchestrator.__QUEUE__)
+                logging.info(
+                    'Enqueued job for adding comments on GitHub for fingerprint %s' % crash_report.fingerprint)
+            else:
+                logging.debug('No pending tasks.')
+
+    @classmethod
+    def create_issue_job(cls, fingerprint):
+        """
+        Handles the create issue job.
+        """
+        try:
+            github_client = GithubClient()
+            crash_report = CrashReport.get_crash(fingerprint)
+            if crash_report is not None:
+                # create the github issue
+                issue = github_client.create_issue(crash_report)
+                logging.info('Created GitHub Issue No(%s) for crash (%s)' % (issue.number, crash_report.fingerprint))
+                # update the crash report with the issue id
+                updated_report = CrashReports.update_crash_report(crash_report.fingerprint, {
+                    # convert to unicode string
+                    'issue': str(issue.number)
+                })
+                logging.info('Updating crash report with fingerprint (%s) complete.' % updated_report.fingerprint)
+        except Exception, e:
+            logging.error('Error creating issue for fingerprint (%s) [%s]' % (fingerprint, e.message))
+
+    @classmethod
+    def add_comment_job(cls, fingerprint):
+        try:
+            github_client = GithubClient()
+            crash_report = CrashReport.get_crash(fingerprint)
+            if crash_report is not None:
+                github_client.create_comment(crash_report)
+        except Exception, e:
+            logging.error('Error creating comment for fingerprint (%s) [%s]' % (fingerprint, e.message))
 
 
 class GithubClient(object):
     """
     A set of github utilities.
     """
+    @classmethod
+    def issue_title(cls, fingerprint):
+        return 'Crash report %s' % fingerprint
+
+    def issue_body(self, fingerprint):
+        crash_report_uri = '%s%s' % (self.reporter_host, crash_uri(fingerprint))
+        body = 'Full report is at [%s](%s)' % (fingerprint, crash_report_uri)
+        return body
+
+    @classmethod
+    def issue_comment(cls, count):
+        new_comment = 'More crashes incoming. Current crash count is at %s.' % count
+        return new_comment
+
     def __init__(self):
         with open('client_secrets.json', 'r') as contents:
             secrets = json.loads(contents.read())
             github_token = secrets.get(TOKEN_KEY)
-            self.github_token = Github(login_or_token=github_token)
+            if is_appengine_local():
+                self.reporter_host = DEBUG_CRASH_REPORTER_HOST
+                self.repo_name = '%s/%s' % (DEBUG_OWNER, DEBUG_REPO)
+            else:
+                self.reporter_host = CRASH_REPORTER_HOST
+                self.repo_name = '%s/%s' % (OWNER, REPO)
+            self.github_client = Github(login_or_token=github_token)
 
     """
     Submits a GitHub issue for a given fingerprint.
     """
-    def submit_issue(self, fingerprint):
-        pass
+    def create_issue(self, crash_report):
+        fingerprint = crash_report.fingerprint
+        # get repository
+        repository = self.github_client.get_repo(self.repo_name)
+
+        # create issue
+        issue = repository.create_issue(
+            title=GithubClient.issue_title(fingerprint),
+            body=self.issue_body(fingerprint),
+            labels=[str(fingerprint)])
+
+        return issue
+
+    """
+    Updates a crash report with the comment.
+    """
+    def create_comment(self, crash_report):
+        count = CrashReport.get_count(crash_report.name)
+        issue_number = int(float(crash_report.issue))
+        comment_body = self.issue_comment(count)
+
+        # get repo
+        repository = self.github_client.get_repo(self.repo_name)
+        issue = repository.get_issue(issue_number)
+        # create comment
+        comment = issue.create_comment(comment_body)
+        return {
+            'issue': issue,
+            'comment': comment
+        }

--- a/github_utils.py
+++ b/github_utils.py
@@ -1,0 +1,23 @@
+import json
+from github import Github
+
+TOKEN_KEY = 'github_token'
+OWNER = 'tessel'
+REPO = 't2-cli'
+
+
+class GithubClient(object):
+    """
+    A set of github utilities.
+    """
+    def __init__(self):
+        with open('client_secrets.json', 'r') as contents:
+            secrets = json.loads(contents.read())
+            github_token = secrets.get(TOKEN_KEY)
+            self.github_token = Github(login_or_token=github_token)
+
+    """
+    Submits a GitHub issue for a given fingerprint.
+    """
+    def submit_issue(self, fingerprint):
+        pass

--- a/github_utils.py
+++ b/github_utils.py
@@ -5,7 +5,7 @@ import logging
 from google.appengine.ext import deferred
 
 from github import Github
-from model import CrashReport
+from model import CrashReport, GlobalPreferences
 from util import is_appengine_local, crash_uri, CrashReports
 
 # constants
@@ -47,6 +47,12 @@ class GithubOrchestrator(object):
         """
         Manages the GitHub issue.
         """
+        # check global github preference
+        preference_value = GlobalPreferences.get_property(GlobalPreferences.__INTEGRATE_WITH_GITHUB__, 'true')
+        if preference_value != 'true':
+            logging.info('GitHub integration is turned off. Ignoring request.')
+            return
+
         if crash_report is not None:
             issue = crash_report.issue
             count = CrashReport.get_count(crash_report.name)
@@ -136,7 +142,7 @@ class GithubClient(object):
 
     @classmethod
     def issue_comment(cls, count):
-        new_comment = 'More crashes incoming. Current crash count is at %s.' % count
+        new_comment = 'More crashes incoming. Current crash count is at `%s`.' % count
         return new_comment
 
     def __init__(self):

--- a/main.py
+++ b/main.py
@@ -1,15 +1,15 @@
 import StringIO
 import csv
+import logging
+import urllib
 
 import webapp2
-import urllib
-import logging
 from webapp2 import uri_for
 
 from common import common_request
 from model import CrashReport, Link
-from util import CrashReports
 from search_model import Search
+from util import CrashReports
 
 
 class RequestHandlerUtils(object):

--- a/model.py
+++ b/model.py
@@ -14,6 +14,40 @@ def to_milliseconds(date_time):
     return int(round(delta.total_seconds() * 1000))
 
 
+class GlobalPreferences(db.Expando):
+
+    # github integration preference
+    __INTEGRATE_WITH_GITHUB__ = 'integrate_with_github'
+
+    """
+    Global preferences that can control the behavior of the crash reporter.
+    """
+    property_name = db.StringProperty()
+    property_value = db.StringProperty()
+
+    @classmethod
+    def key_name(cls, property_name):
+        return cls.kind() + '_' + property_name
+
+    @classmethod
+    def get_property(cls, property_name, default_value=None):
+        key_name = GlobalPreferences.key_name(property_name)
+        preference = GlobalPreferences.get_by_key_name(key_names=key_name)
+        if preference is None:
+            return default_value
+        else:
+            return preference.property_value
+
+    @classmethod
+    def update(cls, property_name, property_value):
+        key_name = GlobalPreferences.key_name(property_name)
+        preference = GlobalPreferences.get_or_insert(key_name, property_name=property_name)
+        preference.property_value = property_value
+        # update
+        db.put(preference)
+        return preference
+
+
 class ShardedCounterConfig(db.Expando):
     """
     Represents the sharded counter config, that helps us figure out how many shards to use for a sharded counter

--- a/model.py
+++ b/model.py
@@ -68,18 +68,13 @@ class CrashReport(db.Expando):
         return int(total)
 
     @classmethod
-    def clear_cache(cls, name):
-        memcache.delete(CrashReport.count_cache_key(name))
-        CrashReport.clear_properties_cache(name)
-
-    @classmethod
     def clear_properties_cache(cls, name):
         keys = list()
         keys.extend(
             CrashReport.recent_crash_property_key(name, key) for key in
             ['date_time', 'state', 'labels', 'issue']
         )
-        memcache.delete_multi(keys)
+        memcache.delete_multi(keys=keys)
 
     @classmethod
     def _most_recent_property(

--- a/model.py
+++ b/model.py
@@ -120,13 +120,20 @@ class CrashReport(db.Expando):
 
     @classmethod
     def add_or_remove(cls, fingerprint, crash, labels=None, is_add=True, delta=1):
+        # use an issue if one already exists
+        issue = CrashReport.most_recent_issue(CrashReport.key_name(fingerprint))
         key_name = CrashReport.key_name(fingerprint)
         config = ShardedCounterConfig.get_sharded_config(key_name)
         shards = config.shards
         shard_to_use = random.randint(0, shards-1)
         shard_key_name = key_name + '_' + str(shard_to_use)
-        crash_report = CrashReport.get_or_insert(shard_key_name,
-                                                 name=key_name, crash=crash, fingerprint=fingerprint, labels=labels)
+        crash_report = CrashReport \
+            .get_or_insert(shard_key_name,
+                           name=key_name,
+                           crash=crash,
+                           fingerprint=fingerprint,
+                           labels=labels,
+                           issue=issue)
         if is_add:
             crash_report.count += delta
             crash_report.put()

--- a/pages/crash-report-macro.html
+++ b/pages/crash-report-macro.html
@@ -22,7 +22,9 @@
       </ul>
       <pre class="prettyprint">{{ crash_report.crash }}</pre>
       {% if crash_report.issue %}
-        <p class="text-info">Github Issue {{ crash_report.issue }}</p>
+        <p class="text-info">
+          Github Issue (<a href="{{ crash_report.issue|issue_url }}">{{ crash_report.issue|issue_url }}</a>)
+        </p>
       {% endif %}
       <p class="text-info">Last report submitted at {{ crash_report.time|readable_date }}</p>
     </div>

--- a/pages/crash-report-macro.html
+++ b/pages/crash-report-macro.html
@@ -21,6 +21,9 @@
         {% endif %}
       </ul>
       <pre class="prettyprint">{{ crash_report.crash }}</pre>
+      {% if crash_report.issue %}
+        <p class="text-info">Github Issue {{ crash_report.issue }}</p>
+      {% endif %}
       <p class="text-info">Last report submitted at {{ crash_report.time|readable_date }}</p>
     </div>
   {% endif %}

--- a/pages/update-global-preferences.html
+++ b/pages/update-global-preferences.html
@@ -1,0 +1,48 @@
+{% extends "base.html" %}
+{% from 'breadcrumbs-macro.html' import render_breadcrumbs %}
+{% from 'nav-macro.html' import render_navbar %}
+{% from 'messages-macro.html' import render_messages %}
+
+{% block navbar %}
+  {{ render_navbar (brand=rrequest.params.brand, links=rrequest.params.nav_links) }}
+{% endblock %}
+
+{% block main %}
+  {# render breadcrumbs #}
+  {{ render_breadcrumbs(crumbs=rrequest.breadcrumbs) }}
+
+  <h2>Update Global Preferences</h2>
+
+  <div class="row">
+    <div class="col-md-8">
+      <form method="post" class="well">
+        <div class="form-group">
+          <label for="integrate_with_github">Integrate with GitHub</label>
+          <select name="integrate_with_github" id="integrate_with_github">
+            <option value="true">True</option>
+            <option value="false">False</option>
+          </select>
+        </div>
+        <div class="form-group">
+          <label for="f">Response Format</label>
+          <select name="f" id="f">
+            <option value="html">HTML</option>
+            <option value="json">JSON</option>
+          </select>
+        </div>
+        <div class="form-group">
+          <label for="pretty">Prettyify</label>
+          <select name="pretty" id="pretty">
+            <option value="true">True</option>
+            <option value="false">False</option>
+          </select>
+        </div>
+        <button type="submit" class="btn btn-default">Submit</button>
+      </form>
+    </div>
+  </div>
+
+  {# render messages #}
+  {{ render_messages(messages=rrequest.messages) }}
+
+{% endblock %}

--- a/queue.yaml
+++ b/queue.yaml
@@ -1,0 +1,4 @@
+queue:
+# github task queue
+- name: github-queue
+  rate: 1/s

--- a/search_model.py
+++ b/search_model.py
@@ -30,6 +30,7 @@ class Search(object):
             search.DateField(name='time', value=crash_report.date_time),
             search.NumberField(name='count', value=CrashReport.get_count(crash_report.name)),
             search.AtomField(name='state', value=crash_report.state),
+            search.AtomField(name='issue', value=crash_report.issue),
         ]
         labels = [search.TextField(name='labels', value=label)
                   for label in crash_report.labels]
@@ -95,7 +96,8 @@ class Search(object):
                     'labels': Search._find_fields(document, 'labels'),
                     'fingerprint': fingerprint,
                     'time': to_milliseconds(Search._find_first(document, 'time')),  # in millis
-                    'count': CrashReport.get_count(CrashReport.key_name(Search._find_first(document, 'fingerprint')))
+                    'count': CrashReport.get_count(CrashReport.key_name(Search._find_first(document, 'fingerprint'))),
+                    'issue': Search._find_first(document, 'issue')
                 }
                 # de-dupe fingerprints
                 if fingerprint not in fingerprints:


### PR DESCRIPTION
## Features
- Crash reports will also track a GitHub issue number.
- They (Github issue numbers) will become a searchable property, as the model is exposed via the search index as well.
- Updates to the issue via comments on repeated instances of crashes.
## Global Hooks
- The ability to turn off Github integration completely, in case of issues or if there is too much noise). 

Addresses most of https://github.com/tessel/t2-crash-reporter/issues/15
